### PR TITLE
refactor(platform): 以 gal 取代 photo_manager 進行圖片儲存

### DIFF
--- a/packages/ap_common_flutter_platform/lib/src/utilities/ap_media_util.dart
+++ b/packages/ap_common_flutter_platform/lib/src/utilities/ap_media_util.dart
@@ -1,13 +1,12 @@
-import 'dart:developer';
 import 'dart:io';
 
 import 'package:ap_common_flutter_core/ap_common_flutter_core.dart';
 import 'package:file_saver/file_saver.dart';
 import 'package:flutter/foundation.dart';
+import 'package:gal/gal.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
-import 'package:photo_manager/photo_manager.dart';
 
 class ApMediaUtil extends MediaUtil {
   @override
@@ -24,39 +23,33 @@ class ApMediaUtil extends MediaUtil {
     required String fileName,
   }) async {
     try {
-      PermissionState hasGrantPermission = PermissionState.notDetermined;
-      if (!kIsWeb && (Platform.isAndroid || Platform.isIOS)) {
-        hasGrantPermission = await PhotoManager.requestPermissionExtend();
-      } else {
-        hasGrantPermission = PermissionState.authorized;
-      }
-      if (hasGrantPermission == PermissionState.authorized ||
-          hasGrantPermission == PermissionState.limited) {
-        final Uint8List pngBytes = byteData.buffer.asUint8List();
-        String filePath = '$fileName.png';
-        if (!kIsWeb && (Platform.isAndroid || Platform.isIOS)) {
-          final String tempPath = path.join(
-            (await getApplicationDocumentsDirectory()).path,
-            filePath,
-          );
-          final File file = await File(tempPath).writeAsBytes(pngBytes);
-          final AssetEntity imageEntity =
-              await PhotoManager.editor.saveImageWithPath(
-            file.path,
-            title: fileName,
-          );
-          file.delete();
-          if (kDebugMode) log(imageEntity.title ?? '');
-        } else {
-          filePath = await FileSaver.instance.saveFile(
-            name: '$fileName.png',
-            bytes: pngBytes,
-          );
-        }
+      final Uint8List pngBytes = byteData.buffer.asUint8List();
+      final String filePath = '$fileName.png';
+      if (!kIsWeb &&
+          (Platform.isAndroid ||
+              Platform.isIOS ||
+              Platform.isMacOS ||
+              Platform.isWindows)) {
+        final String tempPath = path.join(
+          (await getApplicationDocumentsDirectory()).path,
+          filePath,
+        );
+        final File file =
+            await File(tempPath).writeAsBytes(pngBytes);
+        await Gal.putImage(file.path, album: 'AP');
+        await file.delete();
         return SaveImageSuccess(filePath);
       } else {
-        return const SaveImageError('permission_denied');
+        final String savedPath =
+            await FileSaver.instance.saveFile(
+          name: '$fileName.png',
+          bytes: pngBytes,
+        );
+        return SaveImageSuccess(savedPath);
       }
+    } on GalException catch (e, s) {
+      CrashlyticsUtil.instance.recordError(e, s);
+      return SaveImageError(e.type.message);
     } catch (e, s) {
       CrashlyticsUtil.instance.recordError(e, s);
       return SaveImageError(e.toString());

--- a/packages/ap_common_flutter_platform/lib/src/utilities/ap_media_util.dart
+++ b/packages/ap_common_flutter_platform/lib/src/utilities/ap_media_util.dart
@@ -30,14 +30,24 @@ class ApMediaUtil extends MediaUtil {
               Platform.isIOS ||
               Platform.isMacOS ||
               Platform.isWindows)) {
+        if (!await Gal.hasAccess(toAlbum: true)) {
+          if (!await Gal.requestAccess(toAlbum: true)) {
+            return const SaveImageError(
+              'permission_denied',
+            );
+          }
+        }
         final String tempPath = path.join(
-          (await getApplicationDocumentsDirectory()).path,
+          (await getTemporaryDirectory()).path,
           filePath,
         );
         final File file =
             await File(tempPath).writeAsBytes(pngBytes);
-        await Gal.putImage(file.path, album: 'AP');
-        await file.delete();
+        try {
+          await Gal.putImage(file.path, album: 'AP');
+        } finally {
+          await file.delete();
+        }
         return SaveImageSuccess(filePath);
       } else {
         final String savedPath =
@@ -49,7 +59,7 @@ class ApMediaUtil extends MediaUtil {
       }
     } on GalException catch (e, s) {
       CrashlyticsUtil.instance.recordError(e, s);
-      return SaveImageError(e.type.message);
+      return SaveImageError(e.type.name);
     } catch (e, s) {
       CrashlyticsUtil.instance.recordError(e, s);
       return SaveImageError(e.toString());

--- a/packages/ap_common_flutter_platform/pubspec.yaml
+++ b/packages/ap_common_flutter_platform/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   path: ^1.7.0
   path_provider: ^2.1.2
   image_picker: ^1.0.7
-  photo_manager: ^3.6.0
+  gal: ^2.3.2
   file_saver: ^0.2.12
 
 dev_dependencies:

--- a/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
+++ b/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
@@ -644,7 +644,10 @@ class CourseScaffoldState extends State<CourseScaffold> {
       UiUtil.instance.showToast(context, context.ap.unknownError);
       return;
     }
-    final ui.Image image = await boundary.toImage(pixelRatio: 3.0);
+    final double pixelRatio =
+        MediaQuery.devicePixelRatioOf(context).clamp(2.0, 4.0);
+    final ui.Image image =
+        await boundary.toImage(pixelRatio: pixelRatio);
     final ByteData? byteData =
         await image.toByteData(format: ui.ImageByteFormat.png);
     final DateTime now = DateTime.now();


### PR DESCRIPTION
## 摘要
- 將 `photo_manager` 替換為輕量的 `gal` 套件，僅用於儲存課表圖片至相簿
- 移除手動權限管理邏輯，`gal` 內部自行處理權限
- 新增 macOS / Windows 平台支援
- 課表匯出圖片改用裝置實際 pixelRatio（clamp 在 2.0-4.0），取代 hardcoded 3.0

## 變更檔案
- `ap_common_flutter_platform/pubspec.yaml` — `photo_manager` → `gal`
- `ap_common_flutter_platform/lib/src/utilities/ap_media_util.dart` — 改用 `Gal.putImage`，分別捕獲 `GalException`
- `ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart` — 使用 `MediaQuery.devicePixelRatioOf`

## 測試計畫
- [x] `melos run analyze-ci` 通過
- [x] `melos run test` 通過
- [ ] Android 實機測試匯出課表圖片至相簿
- [ ] iOS 實機測試匯出課表圖片至相簿

Closes #165