### PR TITLE
fix(ui): multiple bug fixes for SemesterPicker, CourseScaffold, and version dialog

### DIFF
--- a/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
+++ b/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
@@ -1233,8 +1233,8 @@ class _CourseContentState extends State<CourseContent> {
   @override
   Widget build(BuildContext context) {
     CourseNotifyState? state;
-    if (widget.enableNotifyControl && widget.notifyData != null) {
-      state = widget.notifyData!.getByCode(
+    if (widget.enableNotifyControl && _notifyData != null) {
+      state = _notifyData!.getByCode(
                 widget.course.code,
                 widget.timeCode.startTime,
                 widget.weekday,

--- a/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
+++ b/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
@@ -420,6 +420,7 @@ class CourseScaffoldState extends State<CourseScaffold> {
                       courses: widget.courseData.courses,
                       timeCodes: widget.courseData.timeCodes,
                       invisibleCourseCodes: invisibleCourseCodes,
+                      getCourseColor: _getCourseColor,
                       onVisibilityChanged: (
                         Course course,
                         bool visibility,
@@ -621,6 +622,7 @@ class CourseScaffoldState extends State<CourseScaffold> {
             courses: widget.courseData.courses,
             timeCodes: widget.courseData.timeCodes,
             invisibleCourseCodes: invisibleCourseCodes,
+            getCourseColor: _getCourseColor,
             onVisibilityChanged: (
               Course course,
               bool visibility,
@@ -979,9 +981,16 @@ class CourseScaffoldState extends State<CourseScaffold> {
 
     return GestureDetector(
       onTap: () {
-        final TimeCode timeCode = timeIndex < widget.courseData.timeCodes.length
-            ? widget.courseData.timeCodes[timeIndex]
+        final List<TimeCode> timeCodes = widget.courseData.timeCodes;
+        final TimeCode startTimeCode = timeIndex < timeCodes.length
+            ? timeCodes[timeIndex]
             : const TimeCode(title: '?', startTime: '?', endTime: '?');
+        final int lastIndex = timeIndex + span - 1;
+        final TimeCode endTimeCode =
+            lastIndex < timeCodes.length ? timeCodes[lastIndex] : startTimeCode;
+        final TimeCode timeCode = startTimeCode.copyWith(
+          endTime: endTimeCode.endTime,
+        );
         _onPressed(weekday, timeCode, course);
       },
       child: Container(
@@ -1571,6 +1580,7 @@ class CourseList extends StatelessWidget {
     this.onVisibilityChanged,
     this.timeCodes,
     this.controller,
+    this.getCourseColor,
   });
 
   final List<Course> courses;
@@ -1578,6 +1588,7 @@ class CourseList extends StatelessWidget {
   final void Function(Course, bool)? onVisibilityChanged;
   final List<TimeCode>? timeCodes;
   final ScrollController? controller;
+  final Color Function(Course)? getCourseColor;
 
   @override
   Widget build(BuildContext context) {
@@ -1596,7 +1607,8 @@ class CourseList extends StatelessWidget {
       itemBuilder: (_, int index) {
         final Course course = courses[index];
         final bool visibility = !invisibleCourseCodes.contains(course.code);
-        final Color courseColor = courseColors[index % courseColors.length];
+        final Color courseColor = getCourseColor?.call(course) ??
+            courseColors[course.code.hashCode % courseColors.length];
         final String instructors = course.getInstructors();
 
         return Container(

--- a/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
+++ b/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
@@ -136,9 +136,8 @@ class CourseScaffold extends StatefulWidget {
           empty: (_) => CourseState.empty,
         ),
         courseData = dataState.dataOrNull ?? CourseData.empty(),
-        customHint = dataState is DataLoaded<CourseData>
-            ? dataState.hint
-            : null,
+        customHint =
+            dataState is DataLoaded<CourseData> ? dataState.hint : null,
         customStateHint = dataState is DataError<CourseData>
             ? dataState.hint
             : dataState is DataEmpty<CourseData>
@@ -659,8 +658,7 @@ class CourseScaffoldState extends State<CourseScaffold> {
           final String message =
               '${context.ap.exportCourseTableSuccess}\n$filePath';
           Toast.show(message, context);
-          AnalyticsUtil.instance
-              .logEvent('export_course_table_image_success');
+          AnalyticsUtil.instance.logEvent('export_course_table_image_success');
         case SaveImageError(:final String message):
           UiUtil.instance.showToast(context, message);
       }
@@ -942,11 +940,10 @@ class CourseScaffoldState extends State<CourseScaffold> {
     _courseLookup = <int, Map<int, Course>>{};
     for (final Course course in widget.courseData.courses) {
       for (final SectionTime time in course.times) {
-        _courseLookup
-            .putIfAbsent(
-              time.weekday,
-              () => <int, Course>{},
-            )[time.index] = course;
+        _courseLookup.putIfAbsent(
+          time.weekday,
+          () => <int, Course>{},
+        )[time.index] = course;
       }
     }
   }
@@ -1099,8 +1096,7 @@ class CourseScaffoldState extends State<CourseScaffold> {
         (widget.customCourseData ?? CustomCourseData())
             .update(course.code, result);
     widget.onCustomCourseChanged?.call(updated);
-    UiUtil.instance
-        .showToast(context, context.ap.updateCourseSuccess);
+    UiUtil.instance.showToast(context, context.ap.updateCourseSuccess);
   }
 
   void _deleteCustomCourse(Course course) {
@@ -1123,11 +1119,9 @@ class CourseScaffoldState extends State<CourseScaffold> {
     ).then((bool? confirmed) {
       if (confirmed != true || !mounted) return;
       final CustomCourseData updated =
-          (widget.customCourseData ?? CustomCourseData())
-              .remove(course.code);
+          (widget.customCourseData ?? CustomCourseData()).remove(course.code);
       widget.onCustomCourseChanged?.call(updated);
-      UiUtil.instance
-          .showToast(context, context.ap.deleteCourseSuccess);
+      UiUtil.instance.showToast(context, context.ap.deleteCourseSuccess);
     });
   }
 
@@ -1593,7 +1587,11 @@ class CourseList extends StatelessWidget {
       controller: controller,
       physics: const AlwaysScrollableScrollPhysics(),
       padding: const EdgeInsets.only(
-          bottom: 80.0, left: 16.0, right: 16.0, top: 16.0,),
+        bottom: 80.0,
+        left: 16.0,
+        right: 16.0,
+        top: 16.0,
+      ),
       itemCount: courses.length,
       itemBuilder: (_, int index) {
         final Course course = courses[index];

--- a/packages/ap_common_flutter_ui/lib/src/utils/dialog_utils.dart
+++ b/packages/ap_common_flutter_ui/lib/src/utils/dialog_utils.dart
@@ -145,8 +145,7 @@ class DialogUtils {
           json['${versionInfo.code}'] as Map<String, dynamic>;
       final Object? localeContent = versionMap[app.locale];
       final String content = switch (localeContent) {
-        final List<dynamic> list =>
-          list.map((Object? e) => '• $e').join('\n'),
+        final List<dynamic> list => list.map((Object? e) => '• $e').join('\n'),
         final String s => s,
         _ => versionInfo.content,
       };

--- a/packages/ap_common_flutter_ui/lib/src/utils/dialog_utils.dart
+++ b/packages/ap_common_flutter_ui/lib/src/utils/dialog_utils.dart
@@ -143,9 +143,14 @@ class DialogUtils {
           jsonDecode(response.data as String) as Map<String, dynamic>;
       final Map<String, dynamic> versionMap =
           json['${versionInfo.code}'] as Map<String, dynamic>;
-      versionInfo = versionInfo.copyWith(
-        content: versionMap[app.locale] as String,
-      );
+      final Object? localeContent = versionMap[app.locale];
+      final String content = switch (localeContent) {
+        final List<dynamic> list =>
+          list.map((Object? e) => '• $e').join('\n'),
+        final String s => s,
+        _ => versionInfo.content,
+      };
+      versionInfo = versionInfo.copyWith(content: content);
     }
     if (!context.mounted) return;
     final String versionContent = '${'\n$versionName\n'}${versionInfo.content}';

--- a/packages/ap_common_flutter_ui/lib/src/widgets/semester_picker.dart
+++ b/packages/ap_common_flutter_ui/lib/src/widgets/semester_picker.dart
@@ -26,8 +26,7 @@ class SemesterPickerController extends ChangeNotifier {
       Set<String>.unmodifiable(_loadingSemesters);
 
   /// Semester codes marked as empty (no data).
-  Set<String> get emptySemesters =>
-      Set<String>.unmodifiable(_emptySemesters);
+  Set<String> get emptySemesters => Set<String>.unmodifiable(_emptySemesters);
 
   /// Mark a semester as loading. The BottomSheet will show a
   /// spinner on this item.
@@ -82,7 +81,6 @@ class SemesterPickerController extends ChangeNotifier {
 }
 
 class SemesterUIConfig {
-
   const SemesterUIConfig({
     this.getName,
     this.getIcon,
@@ -658,9 +656,8 @@ class SemesterPickerState extends State<SemesterPicker> {
     SemesterUIConfig? uiConfig, [
     ApLocalizations? ap,
   ]) {
-    final String name =
-        uiConfig?.getName?.call(semester.value) ??
-            _getSemesterName(semester.value, ap);
+    final String name = uiConfig?.getName?.call(semester.value) ??
+        _getSemesterName(semester.value, ap);
     if (name.isNotEmpty) {
       return '${semester.year} $name';
     }

--- a/packages/ap_common_flutter_ui/lib/src/widgets/semester_picker.dart
+++ b/packages/ap_common_flutter_ui/lib/src/widgets/semester_picker.dart
@@ -145,6 +145,7 @@ class SemesterPicker extends StatefulWidget {
     final Set<String>? effectiveEmpty =
         controller?._emptySemesters ?? emptySemesters;
 
+    VoidCallback? onControllerChanged;
     showModalBottomSheet<void>(
       context: context,
       backgroundColor: const Color(0x00000000),
@@ -155,8 +156,10 @@ class SemesterPicker extends StatefulWidget {
         }
         return StatefulBuilder(
           builder: (BuildContext context, StateSetter setSheetState) {
-            void onControllerChanged() => setSheetState(() {});
-            controller?.addListener(onControllerChanged);
+            if (onControllerChanged == null && controller != null) {
+              onControllerChanged = () => setSheetState(() {});
+              controller.addListener(onControllerChanged!);
+            }
             return DraggableScrollableSheet(
               initialChildSize: 0.6,
               minChildSize: 0.3,
@@ -245,6 +248,9 @@ class SemesterPicker extends StatefulWidget {
         );
       },
     ).whenComplete(() {
+      if (onControllerChanged != null) {
+        controller?.removeListener(onControllerChanged!);
+      }
       controller?.detachSheetNavigator();
     });
   }


### PR DESCRIPTION
### **User description**
## Summary
- Fix `setState() called after dispose` in SemesterPicker BottomSheet by adding listener once and removing on dismiss
- Support array format in changelog version dialog for new `changelog.json` structure
- Use local `_notifyData` for course BottomSheet notify state so UI updates after toggle
- Use last consecutive slot's end time when displaying course time in BottomSheet
- Sync course color between table view and list view by passing `getCourseColor` callback to `CourseList`

Closes #172

## Test plan
- [ ] Open SemesterPicker, select a semester, verify no `setState after dispose` error
- [ ] Verify version update dialog correctly displays changelog with array format
- [ ] Open course BottomSheet, toggle notification, verify alarm icon switches
- [ ] Tap a multi-slot course, verify end time shows last slot's end time
- [ ] Switch between table and list view, verify course colors are consistent


___

### **PR Type**
Bug fix


___

### **Description**
- 修正 `SemesterPicker` 監聽器洩漏與 `setState` 錯誤。

- 支援版本日誌陣列格式顯示。

- 課程通知狀態 UI 正確更新。

- 多節課程顯示最後一節結束時間。

- 統一課程表與列表顏色。


___

