### PR TITLE
fix(course): 修正 Widget 會抓到非最新學期課表資料

### DIFF
--- a/apps/example/lib/pages/simple_example/simple_course_page.dart
+++ b/apps/example/lib/pages/simple_example/simple_course_page.dart
@@ -24,7 +24,14 @@ class SimpleCoursePage extends StatelessWidget {
             await rootBundle.loadString(FileAssets.courses);
         return CourseData.fromRawJson(rawString);
       },
-      onCourseLoaded: ApCommonPlugin.updateCourseWidget,
+      onCourseLoaded: (
+        CourseData courseData,
+        bool isDefaultSemester,
+      ) {
+        if (isDefaultSemester) {
+          ApCommonPlugin.updateCourseWidget(courseData);
+        }
+      },
       enableCaptureCourseTable: true,
     );
   }

--- a/packages/ap_common_flutter_ui/lib/src/pages/ap_course_page.dart
+++ b/packages/ap_common_flutter_ui/lib/src/pages/ap_course_page.dart
@@ -39,9 +39,15 @@ class ApCoursePage extends StatefulWidget {
   final Future<CourseData> Function(Semester semester) onLoadCourse;
 
   /// Called after course data is successfully loaded and the UI state
-  /// is updated. Useful for syncing data to platform widgets, e.g.
-  /// `ApCommonPlugin.updateCourseWidget(courseData)`.
-  final void Function(CourseData courseData)? onCourseLoaded;
+  /// is updated. [isDefaultSemester] is `true` when the loaded
+  /// semester matches [SemesterData.defaultIndex].
+  /// Only update platform widgets (e.g.
+  /// `ApCommonPlugin.updateCourseWidget`) when `isDefaultSemester`
+  /// is `true` to avoid overwriting with old semester data.
+  final void Function(
+    CourseData courseData,
+    bool isDefaultSemester,
+  )? onCourseLoaded;
 
   final String? title;
   final bool enableNotifyControl;
@@ -128,7 +134,9 @@ class _ApCoursePageState extends State<ApCoursePage> {
                 courseData.mergeCustom(_customCourseData.courses);
             _state = DataLoaded<CourseData>(merged);
             _notifyData = CourseNotifyData.load(_notifyCacheKey);
-            widget.onCourseLoaded?.call(merged);
+            final bool isDefault = _semesterData!.currentIndex ==
+                _semesterData!.defaultIndex;
+            widget.onCourseLoaded?.call(merged, isDefault);
             _pickerController.markSemesterHasData(semester);
           }
         });


### PR DESCRIPTION
### **User description**
## 摘要
- `onCourseLoaded` callback 新增 `isDefaultSemester` 參數，讓 App 端可判斷目前載入的是否為預設（最新）學期
- 範例 App 改為只在 `isDefaultSemester == true` 時才呼叫 `updateCourseWidget`，避免切換舊學期時覆蓋 Widget 資料

## 測試計畫
- [x] `melos run analyze-ci` 通過
- [x] `melos run test` 通過
- [ ] 切換至舊學期後確認 Widget 資料不被覆蓋
- [ ] 首次載入預設學期後確認 Widget 正確更新

Closes #174


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- 修正 Widget 顯示非最新學期資料的問題。

- `onCourseLoaded` 回呼新增 `isDefaultSemester` 參數。

- 僅在預設學期時更新課程 Widget 資料。

- 避免切換舊學期時覆蓋 Widget 資料。


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ApCoursePage"] -- "載入課程資料" --> B{{"onCourseLoaded 回呼"}};
  B -- "傳遞 courseData, isDefaultSemester" --> C{{"檢查 isDefaultSemester"}};
  C -- "是 (true)" --> D["ApCommonPlugin.updateCourseWidget"];
  C -- "否 (false)" --> E["不更新 Widget"];
```

