### PR TITLE
fix(ui): fix ScoreScaffold gradePoint mode display errors

### DIFF
--- a/packages/ap_common_flutter_ui/lib/src/scaffold/score_scaffold.dart
+++ b/packages/ap_common_flutter_ui/lib/src/scaffold/score_scaffold.dart
@@ -938,12 +938,14 @@ class _ScoreAnalysisTab extends StatelessWidget {
 class ScoreAnalysis {
   ScoreAnalysis(this.scoreData) {
     _scores = <double>[];
+    _gradePoints = <double>[];
     for (final Score score in scoreData.scores) {
       final double? value = _ScoreListTab._parseScore(
         _ScoreListTab._effectiveScoreStr(score),
       );
       if (value != null) {
         _scores.add(value);
+        _gradePoints.add(scoreToGradePoint(value));
       }
     }
     _totalSubjects = _scores.length;
@@ -951,6 +953,7 @@ class ScoreAnalysis {
 
   final ScoreData scoreData;
   late List<double> _scores;
+  late List<double> _gradePoints;
   late int _totalSubjects;
 
   bool get isGradePoint =>
@@ -993,12 +996,13 @@ class ScoreAnalysis {
 
   double get standardDeviation {
     if (_scores.isEmpty) return 0;
+    final List<double> values = isGradePoint ? _gradePoints : _scores;
     final double avg = average;
-    final double sumSquares = _scores.fold<double>(
+    final double sumSquares = values.fold<double>(
       0,
-      (double sum, double score) => sum + (score - avg) * (score - avg),
+      (double sum, double v) => sum + (v - avg) * (v - avg),
     );
-    return sqrt(sumSquares / _scores.length);
+    return sqrt(sumSquares / values.length);
   }
 
   int get estimatedPR {
@@ -1064,6 +1068,8 @@ class ScoreAnalysis {
   }
 
   double get totalCredits {
+    final double? detailCredits = scoreData.detail.creditTaken;
+    if (detailCredits != null && detailCredits > 0) return detailCredits;
     double credits = 0;
     for (final Score score in scoreData.scores) {
       final double? unit = double.tryParse(score.units);
@@ -1073,6 +1079,8 @@ class ScoreAnalysis {
   }
 
   double get passedCredits {
+    final double? detailCredits = scoreData.detail.creditEarned;
+    if (detailCredits != null && detailCredits > 0) return detailCredits;
     double credits = 0;
     for (final Score score in scoreData.scores) {
       final double? scoreValue = _ScoreListTab._parseScore(
@@ -1088,21 +1096,7 @@ class ScoreAnalysis {
     return credits;
   }
 
-  double get failedCredits {
-    double credits = 0;
-    for (final Score score in scoreData.scores) {
-      final double? scoreValue = _ScoreListTab._parseScore(
-        _ScoreListTab._effectiveScoreStr(score),
-      );
-      final double? unit = double.tryParse(score.units);
-      if (scoreValue != null &&
-          !isPassing(scoreValue) &&
-          unit != null) {
-        credits += unit;
-      }
-    }
-    return credits;
-  }
+  double get failedCredits => totalCredits - passedCredits;
 
   /// Returns the effective score string for a [Score], preferring
   /// [Score.semesterScore] and falling back to [Score.finalScore].
@@ -1184,6 +1178,22 @@ class ScoreAnalysis {
     if (score >= 60) return 'C-';
     if (score >= 50) return 'D';
     if (score >= 40) return 'E';
+    return 'F';
+  }
+
+  /// Converts a grade point (等第積分) to a letter grade (等第成績).
+  static String gradePointToGradeLetter(double gpa) {
+    if (gpa >= 4.3) return 'A+';
+    if (gpa >= 4.0) return 'A';
+    if (gpa >= 3.7) return 'A-';
+    if (gpa >= 3.3) return 'B+';
+    if (gpa >= 3.0) return 'B';
+    if (gpa >= 2.7) return 'B-';
+    if (gpa >= 2.3) return 'C+';
+    if (gpa >= 2.0) return 'C';
+    if (gpa >= 1.7) return 'C-';
+    if (gpa >= 1.0) return 'D';
+    if (gpa >= 0.8) return 'E';
     return 'F';
   }
 

--- a/packages/ap_common_flutter_ui/lib/src/widgets/score_analysis_widgets.dart
+++ b/packages/ap_common_flutter_ui/lib/src/widgets/score_analysis_widgets.dart
@@ -651,9 +651,9 @@ class ScoreGPACard extends StatelessWidget {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
     final double gpa = analysis.gpa;
     final Color gpaColor = _getGPAColor(colorScheme, gpa);
-    final String gradeLetter = ScoreAnalysis.scoreToGradeLetter(
-      analysis.average,
-    );
+    final String gradeLetter = analysis.isGradePoint
+        ? ScoreAnalysis.gradePointToGradeLetter(gpa)
+        : ScoreAnalysis.scoreToGradeLetter(analysis.average);
 
     return DecoratedBox(
       decoration: BoxDecoration(


### PR DESCRIPTION
### **User description**
## Summary

修正 ScoreScaffold 在 gradePoint 模式下的三項顯示錯誤（ref: nsysu-code-club/NSYSU-AP#108）：

- **GPA 等第永遠顯示 'F'**：`ScoreGPACard` 將 GPA 值（如 3.5）傳入 `scoreToGradeLetter()`，該方法預期百分制（0-100），導致 3.5 < 40 恆為 'F'。新增 `gradePointToGradeLetter()` 以 GPA 值正確對應等第。
- **標準差計算錯誤**：`standardDeviation` 使用轉換後的百分制分數（A+→95）與 GPA 平均（如 3.5）計算偏差，量綱不一致。改為在 gradePoint 模式下使用等第積分計算。
- **學分統計恆為 0**：學分計算僅從 `Score.units` 解析，若資料不可解析則全為 0。改為優先使用 `Detail.creditTaken`/`creditEarned`，再 fallback 到逐筆計算。

## Test plan

- [ ] 使用 gradePoint 模式的 ScoreData 確認 GPA 卡片等第顯示正確（如 GPA 3.5 → B+）
- [ ] 確認標準差數值在合理範圍內（GPA scale 約 0-2）
- [ ] 確認學分統計顯示 Detail 提供的值
- [ ] 使用 numeric 模式的 ScoreData 確認原有行為不變


___

### **PR Type**
Bug fix


___

### **Description**
- 修正 GPA 卡片等第顯示錯誤。

- 修復標準差計算使用不一致量綱。

- 改進學分統計優先使用詳細資料。

- 新增等第積分轉換為等第成績方法。


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A[ScoreData] --> B{ScoreAnalysis};
    B -- 處理分數與等第積分 --> C[ScoreAnalysis內部邏輯];
    C -- 修正GPA等第轉換 --> D[ScoreGPACard];
    C -- 修正標準差計算 --> E[標準差顯示];
    C -- 修正學分統計邏輯 --> F[學分統計顯示];
```

