### PR TITLE
feat(platform): 整合 Android In-App Update (Google Play API)

### DIFF
--- a/apps/example/lib/pages/diolog_utils_page.dart
+++ b/apps/example/lib/pages/diolog_utils_page.dart
@@ -54,7 +54,35 @@ class _DialogUtilsTestPageState extends State<DialogUtilsTestPage> {
               );
             },
             title: const Text('版本內容對話框'),
-            subtitle: const Text('DialogUtils.showNewVersionContent'),
+            subtitle: const Text('DialogUtils.showUpdateContent'),
+          ),
+          ListTile(
+            onTap: () async {
+              final InAppUpdateInfo? info =
+                  await AppStoreUtil.instance.checkForInAppUpdate();
+              if (!context.mounted) return;
+              if (info == null) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('In-app update not supported'),
+                  ),
+                );
+                return;
+              }
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(
+                    'availability: ${info.updateAvailability}, '
+                    'immediate: ${info.immediateUpdateAllowed}, '
+                    'flexible: ${info.flexibleUpdateAllowed}',
+                  ),
+                ),
+              );
+            },
+            title: const Text('檢查 In-App Update'),
+            subtitle: const Text(
+              'AppStoreUtil.checkForInAppUpdate',
+            ),
           ),
           ListTile(
             onTap: () {

--- a/packages/ap_common_flutter_core/lib/ap_common_flutter_core.dart
+++ b/packages/ap_common_flutter_core/lib/ap_common_flutter_core.dart
@@ -7,6 +7,7 @@ export 'package:dio/dio.dart';
 
 export 'src/l10n/ap_localizations.dart';
 export 'src/models/general_permission_status.dart';
+export 'src/models/in_app_update_info.dart';
 export 'src/ui/ap_icon.dart';
 export 'src/utilities/app_store_util.dart';
 export 'src/utilities/media_util.dart';

--- a/packages/ap_common_flutter_core/lib/src/l10n/strings.g.dart
+++ b/packages/ap_common_flutter_core/lib/src/l10n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 1389 (463 per locale)
+/// Strings: 1395 (465 per locale)
 ///
-/// Built on 2026-04-10 at 17:56 UTC
+/// Built on 2026-04-14 at 00:50 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/packages/ap_common_flutter_core/lib/src/l10n/strings_en.g.dart
+++ b/packages/ap_common_flutter_core/lib/src/l10n/strings_en.g.dart
@@ -290,6 +290,12 @@ class ApLocalizations with BaseTranslations<AppLocale, ApLocalizations> {
 	/// en: 'Update'
 	String get update => 'Update';
 
+	/// en: 'The update has been downloaded. Restart the app to apply.'
+	String get updateDownloadedContent => 'The update has been downloaded. Restart the app to apply.';
+
+	/// en: 'Restart'
+	String get restart => 'Restart';
+
 	/// en: 'Coming Soon~ Donate us to unlock this feature now!'
 	String get functionNotOpen => 'Coming Soon~\nDonate us to unlock this feature now!';
 
@@ -1522,6 +1528,8 @@ extension on ApLocalizations {
 			'updateIosContent' => ({required Object arg1}) => 'An update is available for ${arg1}!',
 			'updateTitle' => 'Updated',
 			'update' => 'Update',
+			'updateDownloadedContent' => 'The update has been downloaded. Restart the app to apply.',
+			'restart' => 'Restart',
 			'functionNotOpen' => 'Coming Soon~\nDonate us to unlock this feature now!',
 			'betaFunction' => 'This is a beta version. Please report any bugs when encountering an error!',
 			'busNotPick' => ({required Object arg1}) => 'Date has not been chosen.\nPlease choose a date first ${arg1}',

--- a/packages/ap_common_flutter_core/lib/src/l10n/strings_en.json
+++ b/packages/ap_common_flutter_core/lib/src/l10n/strings_en.json
@@ -82,6 +82,8 @@
   "updateIosContent": "An update is available for $arg1!",
   "updateTitle": "Updated",
   "update": "Update",
+  "updateDownloadedContent": "The update has been downloaded. Restart the app to apply.",
+  "restart": "Restart",
   "functionNotOpen": "Coming Soon~\nDonate us to unlock this feature now!",
   "betaFunction": "This is a beta version. Please report any bugs when encountering an error!",
   "busNotPick": "Date has not been chosen.\nPlease choose a date first $arg1",

--- a/packages/ap_common_flutter_core/lib/src/l10n/strings_ja.g.dart
+++ b/packages/ap_common_flutter_core/lib/src/l10n/strings_ja.g.dart
@@ -122,6 +122,8 @@ class ApLocalizationsJa extends ApLocalizations with BaseTranslations<AppLocale,
 	@override String updateIosContent({required Object arg1}) => '${arg1}のApp Storeに新しいバージョンがあります！';
 	@override String get updateTitle => 'アップデート';
 	@override String get update => '更新';
+	@override String get updateDownloadedContent => 'アップデートのダウンロードが完了しました。アプリを再起動して適用してください。';
+	@override String get restart => '再起動';
 	@override String get functionNotOpen => 'この機能はまだ開放されていません～\nファンページで開放時期をお知らせします！';
 	@override String get betaFunction => 'この機能はベータ版です。問題があればすぐにご報告ください！';
 	@override String busNotPick({required Object arg1}) => '日付が選択されていません！\n先に日付を選んでください ${arg1}';
@@ -595,6 +597,8 @@ extension on ApLocalizationsJa {
 			'updateIosContent' => ({required Object arg1}) => '${arg1}のApp Storeに新しいバージョンがあります！',
 			'updateTitle' => 'アップデート',
 			'update' => '更新',
+			'updateDownloadedContent' => 'アップデートのダウンロードが完了しました。アプリを再起動して適用してください。',
+			'restart' => '再起動',
 			'functionNotOpen' => 'この機能はまだ開放されていません～\nファンページで開放時期をお知らせします！',
 			'betaFunction' => 'この機能はベータ版です。問題があればすぐにご報告ください！',
 			'busNotPick' => ({required Object arg1}) => '日付が選択されていません！\n先に日付を選んでください ${arg1}',

--- a/packages/ap_common_flutter_core/lib/src/l10n/strings_ja.json
+++ b/packages/ap_common_flutter_core/lib/src/l10n/strings_ja.json
@@ -82,6 +82,8 @@
   "updateIosContent": "$arg1のApp Storeに新しいバージョンがあります！",
   "updateTitle": "アップデート",
   "update": "更新",
+  "updateDownloadedContent": "アップデートのダウンロードが完了しました。アプリを再起動して適用してください。",
+  "restart": "再起動",
   "functionNotOpen": "この機能はまだ開放されていません～\nファンページで開放時期をお知らせします！",
   "betaFunction": "この機能はベータ版です。問題があればすぐにご報告ください！",
   "busNotPick": "日付が選択されていません！\n先に日付を選んでください $arg1",

--- a/packages/ap_common_flutter_core/lib/src/l10n/strings_zh-Hant-TW.json
+++ b/packages/ap_common_flutter_core/lib/src/l10n/strings_zh-Hant-TW.json
@@ -82,6 +82,8 @@
   "updateIosContent": "$arg1 在 Apple store 有新版本喲！",
   "updateTitle": "版本更新",
   "update": "更新",
+  "updateDownloadedContent": "更新已下載完成，重新啟動即可套用。",
+  "restart": "重新啟動",
   "functionNotOpen": "功能尚未開放\n私密粉絲團 小編會告訴你何時開放！",
   "betaFunction": "此功能為測試版本，如有問題請立即回報！",
   "busNotPick": "您尚未選擇日期！\n請先選擇日期 $arg1",

--- a/packages/ap_common_flutter_core/lib/src/l10n/strings_zh_Hant_TW.g.dart
+++ b/packages/ap_common_flutter_core/lib/src/l10n/strings_zh_Hant_TW.g.dart
@@ -122,6 +122,8 @@ class ApLocalizationsZhHantTw extends ApLocalizations with BaseTranslations<AppL
 	@override String updateIosContent({required Object arg1}) => '${arg1} 在 Apple store 有新版本喲！';
 	@override String get updateTitle => '版本更新';
 	@override String get update => '更新';
+	@override String get updateDownloadedContent => '更新已下載完成，重新啟動即可套用。';
+	@override String get restart => '重新啟動';
 	@override String get functionNotOpen => '功能尚未開放\n私密粉絲團 小編會告訴你何時開放！';
 	@override String get betaFunction => '此功能為測試版本，如有問題請立即回報！';
 	@override String busNotPick({required Object arg1}) => '您尚未選擇日期！\n請先選擇日期 ${arg1}';
@@ -595,6 +597,8 @@ extension on ApLocalizationsZhHantTw {
 			'updateIosContent' => ({required Object arg1}) => '${arg1} 在 Apple store 有新版本喲！',
 			'updateTitle' => '版本更新',
 			'update' => '更新',
+			'updateDownloadedContent' => '更新已下載完成，重新啟動即可套用。',
+			'restart' => '重新啟動',
 			'functionNotOpen' => '功能尚未開放\n私密粉絲團 小編會告訴你何時開放！',
 			'betaFunction' => '此功能為測試版本，如有問題請立即回報！',
 			'busNotPick' => ({required Object arg1}) => '您尚未選擇日期！\n請先選擇日期 ${arg1}',

--- a/packages/ap_common_flutter_core/lib/src/models/in_app_update_info.dart
+++ b/packages/ap_common_flutter_core/lib/src/models/in_app_update_info.dart
@@ -1,0 +1,18 @@
+enum InAppUpdateAvailability {
+  unknown,
+  updateNotAvailable,
+  updateAvailable,
+  updateInProgress,
+}
+
+class InAppUpdateInfo {
+  const InAppUpdateInfo({
+    required this.updateAvailability,
+    required this.immediateUpdateAllowed,
+    required this.flexibleUpdateAllowed,
+  });
+
+  final InAppUpdateAvailability updateAvailability;
+  final bool immediateUpdateAllowed;
+  final bool flexibleUpdateAllowed;
+}

--- a/packages/ap_common_flutter_core/lib/src/utilities/app_store_util.dart
+++ b/packages/ap_common_flutter_core/lib/src/utilities/app_store_util.dart
@@ -1,5 +1,6 @@
 import 'package:ap_common_core/injector.dart';
 import 'package:ap_common_flutter_core/src/models/general_permission_status.dart';
+import 'package:ap_common_flutter_core/src/models/in_app_update_info.dart';
 
 abstract class AppStoreUtil {
   static AppStoreUtil get instance => injector.get<AppStoreUtil>();
@@ -13,4 +14,17 @@ abstract class AppStoreUtil {
   });
 
   Future<void> requestTrackingAuthorization();
+
+  /// Check if an in-app update is available.
+  /// Returns `null` on unsupported platforms.
+  Future<InAppUpdateInfo?> checkForInAppUpdate() async => null;
+
+  /// Perform an immediate (blocking) in-app update.
+  Future<void> performImmediateUpdate() async {}
+
+  /// Start a flexible (background download) in-app update.
+  Future<void> startFlexibleUpdate() async {}
+
+  /// Complete a flexible update after the download finishes.
+  Future<void> completeFlexibleUpdate() async {}
 }

--- a/packages/ap_common_flutter_platform/lib/src/utilities/app_store_util.dart
+++ b/packages/ap_common_flutter_platform/lib/src/utilities/app_store_util.dart
@@ -4,6 +4,7 @@ import 'package:ap_common_flutter_core/ap_common_flutter_core.dart';
 import 'package:app_tracking_transparency/app_tracking_transparency.dart';
 import 'package:flutter/foundation.dart';
 import 'package:in_app_review/in_app_review.dart';
+import 'package:in_app_update/in_app_update.dart';
 
 class ApAppStoreUtil extends AppStoreUtil {
   @override
@@ -43,5 +44,44 @@ class ApAppStoreUtil extends AppStoreUtil {
   @override
   Future<void> requestTrackingAuthorization() {
     return AppTrackingTransparency.requestTrackingAuthorization();
+  }
+
+  @override
+  Future<InAppUpdateInfo?> checkForInAppUpdate() async {
+    if (kIsWeb || !Platform.isAndroid) return null;
+    try {
+      final AppUpdateInfo info = await InAppUpdate.checkForUpdate();
+      return InAppUpdateInfo(
+        updateAvailability: switch (info.updateAvailability) {
+          UpdateAvailability.updateAvailable =>
+            InAppUpdateAvailability.updateAvailable,
+          UpdateAvailability.updateNotAvailable =>
+            InAppUpdateAvailability.updateNotAvailable,
+          UpdateAvailability
+                .developerTriggeredUpdateInProgress =>
+            InAppUpdateAvailability.updateInProgress,
+          _ => InAppUpdateAvailability.unknown,
+        },
+        immediateUpdateAllowed: info.immediateUpdateAllowed,
+        flexibleUpdateAllowed: info.flexibleUpdateAllowed,
+      );
+    } on Exception {
+      return null;
+    }
+  }
+
+  @override
+  Future<void> performImmediateUpdate() async {
+    await InAppUpdate.performImmediateUpdate();
+  }
+
+  @override
+  Future<void> startFlexibleUpdate() async {
+    await InAppUpdate.startFlexibleUpdate();
+  }
+
+  @override
+  Future<void> completeFlexibleUpdate() async {
+    await InAppUpdate.completeFlexibleUpdate();
   }
 }

--- a/packages/ap_common_flutter_platform/pubspec.yaml
+++ b/packages/ap_common_flutter_platform/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   package_info_plus: ^8.3.0
   add_2_calendar: ^3.0.1
   in_app_review: ^2.0.3
+  in_app_update: ^4.2.5
   path: ^1.7.0
   path_provider: ^2.1.2
   image_picker: ^1.0.7

--- a/packages/ap_common_flutter_ui/lib/src/utils/dialog_utils.dart
+++ b/packages/ap_common_flutter_ui/lib/src/utils/dialog_utils.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:ap_common_flutter_ui/ap_common_flutter_ui.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:sprintf/sprintf.dart';
@@ -172,6 +173,49 @@ class DialogUtils {
       ),
     );
     if (versionDiff > 0) {
+      // Try Android in-app update via Google Play API
+      if (!kIsWeb && Platform.isAndroid) {
+        try {
+          final InAppUpdateInfo? updateInfo =
+              await AppStoreUtil.instance.checkForInAppUpdate();
+          if (updateInfo?.updateAvailability ==
+              InAppUpdateAvailability.updateAvailable) {
+            if (versionInfo.isForceUpdate &&
+                updateInfo!.immediateUpdateAllowed) {
+              await AppStoreUtil.instance.performImmediateUpdate();
+              return;
+            } else if (updateInfo!.flexibleUpdateAllowed) {
+              await AppStoreUtil.instance.startFlexibleUpdate();
+              if (!context.mounted) return;
+              showDialog(
+                context: context,
+                builder: (BuildContext context) => DefaultDialog(
+                  title: app.updateTitle,
+                  contentWidget: Text(
+                    app.updateDownloadedContent,
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      color: Theme.of(context)
+                          .colorScheme
+                          .onSurfaceVariant,
+                      height: 1.3,
+                      fontSize: 16.0,
+                    ),
+                  ),
+                  actionText: app.restart,
+                  actionFunction: () {
+                    AppStoreUtil.instance.completeFlexibleUpdate();
+                  },
+                ),
+              );
+              return;
+            }
+          }
+          // ignore: avoid_catches_without_on_clauses
+        } catch (_) {
+          // Fall through to default dialog behavior
+        }
+      }
       if (versionInfo.isForceUpdate) {
         //ignore: use_build_context_synchronously
         if (!context.mounted) return;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -741,6 +741,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  gal:
+    dependency: transitive
+    description:
+      name: gal
+      sha256: "969598f986789127fd407a750413249e1352116d4c2be66e81837ffeeaafdfee"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   glob:
     dependency: transitive
     description:
@@ -957,6 +965,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.5"
+  in_app_update:
+    dependency: transitive
+    description:
+      name: in_app_update
+      sha256: "9924a3efe592e1c0ec89dda3683b3cfec3d4cd02d908e6de00c24b759038ddb1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.5"
   injector:
     dependency: transitive
     description:
@@ -1269,14 +1285,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.2"
-  photo_manager:
-    dependency: transitive
-    description:
-      name: photo_manager
-      sha256: fb3bc8ea653370f88742b3baa304700107c83d12748aa58b2b9f2ed3ef15e6c2
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.9.0"
   photo_view:
     dependency: transitive
     description:


### PR DESCRIPTION
### **User description**
## 摘要
- 新增 `in_app_update` 套件依賴，透過 Google Play In-App Updates API 實現 Android 原生應用內更新
- 在 `AppStoreUtil` 抽象層新增 4 個方法（`checkForInAppUpdate`、`performImmediateUpdate`、`startFlexibleUpdate`、`completeFlexibleUpdate`），提供預設空實作以保持向後相容
- 新增 `InAppUpdateInfo` 模型與 `InAppUpdateAvailability` 列舉
- 修改 `DialogUtils.showNewVersionContent`：Android 平台優先嘗試 in-app update（強制更新→Immediate 模式，非強制→Flexible 模式），失敗時 fallback 到原有 Play Store 導向
- 新增 `updateDownloadedContent`、`restart` 多語系翻譯（en / zh-Hant-TW / ja）
- Example App 新增「檢查 In-App Update」測試按鈕

## 測試計畫
- [x] `melos run analyze` — 全部 9 個套件通過
- [x] `melos run test` — 全部測試通過
- [ ] Android 實機測試 In-App Update（需透過 Google Play 內部測試版本）

Closes #22


___

### **PR Type**
Enhancement


___

### **Description**
- 整合 Android 應用內更新功能 (Google Play API)。

- 擴充 `AppStoreUtil` 抽象層以支援應用內更新。

- 調整 `DialogUtils` 邏輯以優先處理應用內更新。

- 新增應用內更新相關的多語系字串。


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A[DialogUtils] --> B{Android平台?};
    B -- 是 --> C[AppStoreUtil.checkForInAppUpdate];
    C --> D{更新類型?};
    D -- 立即更新 --> E[AppStoreUtil.performImmediateUpdate];
    D -- 彈性更新 --> F[AppStoreUtil.startFlexibleUpdate];
    F --> G[顯示下載完成對話框];
    G --> H[AppStoreUtil.completeFlexibleUpdate];
    C -- 無更新/失敗 --> I[導向 Play 商店];
    B -- 否 --> I;
```

