### PR TITLE
feat(ui): 新增可切換課表配色系統 CoursePaletteTheme

### DIFF
--- a/packages/ap_common_flutter_ui/lib/ap_common_flutter_ui.dart
+++ b/packages/ap_common_flutter_ui/lib/ap_common_flutter_ui.dart
@@ -14,6 +14,7 @@ export 'src/scaffold/image_viewer_scaffold.dart';
 export 'src/scaffold/login_scaffold.dart';
 export 'src/scaffold/score_scaffold.dart';
 export 'src/scaffold/user_info_scaffold.dart';
+export 'src/theme/course_palette_theme.dart';
 export 'src/utils/ap_ui_util.dart';
 export 'src/utils/ap_utils.dart';
 export 'src/utils/app_tracking_utils.dart';

--- a/packages/ap_common_flutter_ui/lib/ap_common_flutter_ui.dart
+++ b/packages/ap_common_flutter_ui/lib/ap_common_flutter_ui.dart
@@ -28,6 +28,7 @@ export 'src/widgets/ap_drawer.dart';
 export 'src/widgets/ap_network_image.dart';
 export 'src/widgets/color_picker_widgets.dart';
 export 'src/widgets/course_edit_sheet.dart';
+export 'src/widgets/course_palette_picker_sheet.dart';
 export 'src/widgets/default_dialog.dart';
 export 'src/widgets/dialog_option.dart';
 export 'src/widgets/hint_banner.dart';

--- a/packages/ap_common_flutter_ui/lib/src/pages/ap_app.dart
+++ b/packages/ap_common_flutter_ui/lib/src/pages/ap_app.dart
@@ -55,6 +55,7 @@ class ApApp extends StatefulWidget {
     this.debugShowCheckedModeBanner = false,
     this.navigatorObservers = const <NavigatorObserver>[],
     this.onGenerateRoute,
+    this.coursePalette = CoursePaletteTheme.material,
   });
 
   /// The default route widget.
@@ -86,6 +87,11 @@ class ApApp extends StatefulWidget {
 
   /// Custom route generation.
   final RouteFactory? onGenerateRoute;
+
+  /// Palette used by course-related widgets (CourseScaffold, list,
+  /// CourseContent, CourseEditSheet, home dashboard). Defaults to
+  /// [CoursePaletteTheme.material] so existing apps keep their look.
+  final CoursePaletteTheme coursePalette;
 
   /// Find the nearest [ApAppState] in the widget tree.
   static ApAppState of(BuildContext context) {
@@ -215,8 +221,14 @@ class ApAppState extends State<ApApp> with WidgetsBindingObserver {
                       ...widget.routes,
                     },
                     onGenerateRoute: widget.onGenerateRoute,
-                    theme: ApTheme.light(seedColor),
-                    darkTheme: ApTheme.dark(seedColor),
+                    theme: ApTheme.light(
+                      seedColor,
+                      coursePalette: widget.coursePalette,
+                    ),
+                    darkTheme: ApTheme.dark(
+                      seedColor,
+                      coursePalette: widget.coursePalette,
+                    ),
                     themeMode: _themeMode,
                     locale: TranslationProvider.of(context).flutterLocale,
                     navigatorObservers: widget.navigatorObservers,

--- a/packages/ap_common_flutter_ui/lib/src/resources/ap_theme.dart
+++ b/packages/ap_common_flutter_ui/lib/src/resources/ap_theme.dart
@@ -1,6 +1,7 @@
 import 'package:ap_common_flutter_core/ap_common_flutter_core.dart';
 import 'package:ap_common_flutter_ui/src/resources/ap_colors.dart';
 import 'package:ap_common_flutter_ui/src/resources/resources.dart';
+import 'package:ap_common_flutter_ui/src/theme/course_palette_theme.dart';
 import 'package:flutter/material.dart';
 
 export 'package:cupertino_back_gesture/cupertino_back_gesture.dart';
@@ -364,22 +365,31 @@ class ApTheme extends InheritedWidget {
     }
   }
 
-  static ThemeData light(Color seedColor) {
+  static ThemeData light(
+    Color seedColor, {
+    CoursePaletteTheme coursePalette = CoursePaletteTheme.material,
+  }) {
     final ColorScheme colorScheme = ColorScheme.fromSeed(
       seedColor: seedColor,
     );
-    return _buildTheme(colorScheme);
+    return _buildTheme(colorScheme, coursePalette);
   }
 
-  static ThemeData dark(Color seedColor) {
+  static ThemeData dark(
+    Color seedColor, {
+    CoursePaletteTheme coursePalette = CoursePaletteTheme.material,
+  }) {
     final ColorScheme colorScheme = ColorScheme.fromSeed(
       seedColor: seedColor,
       brightness: Brightness.dark,
     );
-    return _buildTheme(colorScheme);
+    return _buildTheme(colorScheme, coursePalette);
   }
 
-  static ThemeData _buildTheme(ColorScheme colorScheme) {
+  static ThemeData _buildTheme(
+    ColorScheme colorScheme,
+    CoursePaletteTheme coursePalette,
+  ) {
     final bool isLight = colorScheme.brightness == Brightness.light;
 
     return ThemeData(
@@ -388,6 +398,7 @@ class ApTheme extends InheritedWidget {
       scaffoldBackgroundColor: colorScheme.surface,
       pageTransitionsTheme: _pageTransitionsTheme,
       visualDensity: VisualDensity.adaptivePlatformDensity,
+      extensions: <ThemeExtension<dynamic>>[coursePalette],
       appBarTheme: AppBarTheme(
         centerTitle: true,
         elevation: 0,

--- a/packages/ap_common_flutter_ui/lib/src/resources/ap_theme.dart
+++ b/packages/ap_common_flutter_ui/lib/src/resources/ap_theme.dart
@@ -69,6 +69,27 @@ class ApTheme extends InheritedWidget {
     ThemeColor(name: '棕褐', color: Color(0xFF5D4037)),
   ];
 
+  /// iOS System Colors (light variant) packaged as seed colors so apps
+  /// can opt into an iOS-flavoured tonal palette via
+  /// `ColorScheme.fromSeed`. Same length as [themeColors], so it is a
+  /// drop-in replacement wherever [currentColorIndex] is used — pass
+  /// the chosen entry's color into [ApTheme.light] / [ApTheme.dark] or
+  /// store it under [PREF_CUSTOM_COLOR].
+  ///
+  /// The values are stable from iOS 13 through iOS 26.
+  static const List<ThemeColor> iOSThemeColors = <ThemeColor>[
+    ThemeColor(name: 'iOS 藍', color: Color(0xFF007AFF)),
+    ThemeColor(name: 'iOS 靛', color: Color(0xFF5856D6)),
+    ThemeColor(name: 'iOS 綠', color: Color(0xFF34C759)),
+    ThemeColor(name: 'iOS 橙', color: Color(0xFFFF9500)),
+    ThemeColor(name: 'iOS 紫', color: Color(0xFFAF52DE)),
+    ThemeColor(name: 'iOS 粉紅', color: Color(0xFFFF2D55)),
+    ThemeColor(name: 'iOS 青', color: Color(0xFF30B0C7)),
+    ThemeColor(name: 'iOS 黃', color: Color(0xFFFFCC00)),
+    ThemeColor(name: 'iOS 紅', color: Color(0xFFFF3B30)),
+    ThemeColor(name: 'iOS 棕', color: Color(0xFFA2845E)),
+  ];
+
   static const int customColorIndex = -1;
 
   // ignore: constant_identifier_names

--- a/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
+++ b/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
@@ -1109,7 +1109,7 @@ class CourseScaffoldState extends State<CourseScaffold> {
         margin: const EdgeInsets.all(2),
         padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 6),
         decoration: BoxDecoration(
-          color: courseColor,
+          color: courseColor.withAlpha(CoursePaletteTheme.cardAlpha),
           borderRadius: BorderRadius.circular(8),
           boxShadow: <BoxShadow>[
             BoxShadow(

--- a/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
+++ b/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
@@ -196,6 +196,25 @@ class CourseScaffold extends StatefulWidget {
   /// Called whenever the user picks a new palette from the selector.
   /// Apps can use this to update their app-level theme extensions so
   /// the new palette applies to other surfaces (home dashboard, etc.).
+  ///
+  /// If the app uses `ap_common_plugin` for native AppWidgets, also
+  /// forward the palette to native so the home-screen widget stays
+  /// in sync:
+  ///
+  /// ```dart
+  /// onCoursePaletteChanged: (CoursePaletteTheme palette) {
+  ///   ApCommonPlugin.setCoursePalette(
+  ///     id: palette.id,
+  ///     colors: palette.colors
+  ///         .map((Color c) => c.toARGB32()).toList(),
+  ///     foregroundColor: palette.foregroundColor.toARGB32(),
+  ///     darkColors: palette.dark?.colors
+  ///         .map((Color c) => c.toARGB32()).toList(),
+  ///     darkForegroundColor:
+  ///         palette.dark?.foregroundColor.toARGB32(),
+  ///   );
+  /// }
+  /// ```
   final ValueChanged<CoursePaletteTheme>? onCoursePaletteChanged;
 
   @override

--- a/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
+++ b/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
@@ -206,21 +206,15 @@ class CourseScaffoldState extends State<CourseScaffold> {
 
   late Map<int, Map<int, Course>> _courseLookup;
 
-  final Map<String, Color> _courseColorMap = <String, Color>{};
+  final Map<String, int> _courseColorIndexMap = <String, int>{};
   int _colorIndex = 0;
 
-  Color _getCourseColor(Course course) {
-    if (!_courseColorMap.containsKey(course.code)) {
-      if (course.colorIndex != null) {
-        _courseColorMap[course.code] =
-            courseColors[course.colorIndex! % courseColors.length];
-      } else {
-        _courseColorMap[course.code] =
-            courseColors[_colorIndex % courseColors.length];
-        _colorIndex++;
-      }
-    }
-    return _courseColorMap[course.code]!;
+  Color _getCourseColor(Course course, CoursePaletteTheme palette) {
+    final int index = _courseColorIndexMap.putIfAbsent(course.code, () {
+      if (course.colorIndex != null) return course.colorIndex!;
+      return _colorIndex++;
+    });
+    return palette.colorAt(index);
   }
 
   late ScrollController _scrollController;
@@ -955,7 +949,8 @@ class CourseScaffoldState extends State<CourseScaffold> {
     Course course,
     int span,
   ) {
-    final Color courseColor = _getCourseColor(course);
+    final CoursePaletteTheme palette = CoursePaletteTheme.of(context);
+    final Color courseColor = _getCourseColor(course, palette);
     final String locationInfo =
         (showClassroomLocation ?? true) && course.location != null
             ? course.location.toString()
@@ -963,10 +958,7 @@ class CourseScaffoldState extends State<CourseScaffold> {
     final String instructorInfo =
         (showInstructors ?? true) ? course.getInstructors() : '';
 
-    final Color onCourseColor =
-        ThemeData.estimateBrightnessForColor(courseColor) == Brightness.dark
-            ? Colors.white
-            : Colors.black;
+    final Color onCourseColor = palette.foregroundColor;
 
     final String displayInfo = <String>[
       if (instructorInfo.isNotEmpty) instructorInfo,
@@ -1243,12 +1235,10 @@ class _CourseContentState extends State<CourseContent> {
     final bool visibility =
         !widget.invisibleCourseCodes.contains(widget.course.code);
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final CoursePaletteTheme palette = CoursePaletteTheme.of(context);
     final Color courseColor = widget.courseColor ??
-        courseColors[widget.course.code.hashCode % courseColors.length];
-    final Color onCourseColor =
-        ThemeData.estimateBrightnessForColor(courseColor) == Brightness.dark
-            ? Colors.white
-            : Colors.black;
+        palette.colorAt(widget.course.code.hashCode);
+    final Color onCourseColor = palette.foregroundColor;
     return Container(
       decoration: BoxDecoration(
         color: colorScheme.surface,
@@ -1587,6 +1577,7 @@ class CourseList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final CoursePaletteTheme palette = CoursePaletteTheme.of(context);
 
     return ListView.builder(
       controller: controller,
@@ -1602,7 +1593,7 @@ class CourseList extends StatelessWidget {
         final Course course = courses[index];
         final bool visibility = !invisibleCourseCodes.contains(course.code);
         final Color courseColor = getCourseColor?.call(course) ??
-            courseColors[course.code.hashCode % courseColors.length];
+            palette.colorAt(course.code.hashCode);
         final String instructors = course.getInstructors();
 
         return Container(

--- a/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
+++ b/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
@@ -228,8 +228,11 @@ class CourseScaffoldState extends State<CourseScaffold> {
   /// scaffold's subtree. `null` means "inherit from Theme".
   CoursePaletteTheme? _overridePalette;
 
-  CoursePaletteTheme _activePalette(BuildContext context) =>
-      _overridePalette ?? CoursePaletteTheme.of(context);
+  CoursePaletteTheme _activePalette(BuildContext context) {
+    final CoursePaletteTheme? override = _overridePalette;
+    if (override != null) return override.resolvedFor(context);
+    return CoursePaletteTheme.of(context);
+  }
 
   Color _getCourseColor(Course course) {
     final int index = _courseColorIndexMap.putIfAbsent(course.code, () {

--- a/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
+++ b/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+import 'dart:developer';
 import 'dart:io';
 import 'dart:ui' as ui;
 
@@ -5,6 +7,7 @@ import 'package:ap_common_flutter_ui/ap_common_flutter_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 
 typedef CourseNotifyCallback = Function(
   CourseNotify? courseNotify,
@@ -197,24 +200,10 @@ class CourseScaffold extends StatefulWidget {
   /// Apps can use this to update their app-level theme extensions so
   /// the new palette applies to other surfaces (home dashboard, etc.).
   ///
-  /// If the app uses `ap_common_plugin` for native AppWidgets, also
-  /// forward the palette to native so the home-screen widget stays
-  /// in sync:
-  ///
-  /// ```dart
-  /// onCoursePaletteChanged: (CoursePaletteTheme palette) {
-  ///   ApCommonPlugin.setCoursePalette(
-  ///     id: palette.id,
-  ///     colors: palette.colors
-  ///         .map((Color c) => c.toARGB32()).toList(),
-  ///     foregroundColor: palette.foregroundColor.toARGB32(),
-  ///     darkColors: palette.dark?.colors
-  ///         .map((Color c) => c.toARGB32()).toList(),
-  ///     darkForegroundColor:
-  ///         palette.dark?.foregroundColor.toARGB32(),
-  ///   );
-  /// }
-  /// ```
+  /// Native AppWidget sync via `ap_common_plugin` is handled
+  /// automatically — the scaffold invokes the plugin's
+  /// `setCoursePalette` channel after persisting the choice, and
+  /// silently no-ops when the plugin isn't registered.
   final ValueChanged<CoursePaletteTheme>? onCoursePaletteChanged;
 
   @override
@@ -284,7 +273,10 @@ class CourseScaffoldState extends State<CourseScaffold> {
     final String savedPaletteId =
         PreferenceUtil.instance.getString(CoursePaletteTheme.preferenceKey, '');
     if (savedPaletteId.isNotEmpty) {
-      _overridePalette = CoursePaletteTheme.fromId(savedPaletteId);
+      final CoursePaletteTheme persisted =
+          CoursePaletteTheme.fromId(savedPaletteId);
+      _overridePalette = persisted;
+      unawaited(_syncCoursePaletteToNative(persisted));
     }
     fetchInvisibleCourseCodes();
     _scrollController = ScrollController();
@@ -339,6 +331,46 @@ class CourseScaffoldState extends State<CourseScaffold> {
     );
   }
 
+  /// Push the active palette to `ap_common_plugin`'s native handler
+  /// so Android / iOS home-screen widgets render with the same colors
+  /// the user just picked. Opens the channel directly to avoid making
+  /// `ap_common_flutter_ui` depend on the plugin package; when the
+  /// plugin isn't registered (web, or app not using the plugin) the
+  /// resulting [MissingPluginException] is swallowed.
+  static const MethodChannel _nativePaletteChannel =
+      MethodChannel('ap_common_plugin');
+
+  Future<void> _syncCoursePaletteToNative(
+    CoursePaletteTheme palette,
+  ) async {
+    final CoursePaletteTheme? darkVariant = palette.dark;
+    final Map<String, Object?> args = <String, Object?>{
+      'id': palette.id,
+      'colors': <int>[
+        for (final Color c in palette.colors) c.toARGB32(),
+      ],
+      'foregroundColor': palette.foregroundColor.toARGB32(),
+      if (darkVariant != null) ...<String, Object?>{
+        'darkColors': <int>[
+          for (final Color c in darkVariant.colors) c.toARGB32(),
+        ],
+        'darkForegroundColor': darkVariant.foregroundColor.toARGB32(),
+      },
+    };
+    try {
+      await _nativePaletteChannel.invokeMethod<void>(
+        'setCoursePalette',
+        args,
+      );
+    } on MissingPluginException catch (e) {
+      log(
+        'CourseScaffold: native palette sync unavailable '
+        '(${e.message}); home widget will keep its previous colors.',
+        name: 'CourseScaffold',
+      );
+    }
+  }
+
   Future<void> _showPalettePicker() async {
     final CoursePaletteTheme current = _activePalette(context);
     final CoursePaletteTheme? picked = await CoursePalettePickerSheet.show(
@@ -349,6 +381,7 @@ class CourseScaffoldState extends State<CourseScaffold> {
     if (picked == null || picked.id == current.id) return;
     await PreferenceUtil.instance
         .setString(CoursePaletteTheme.preferenceKey, picked.id);
+    unawaited(_syncCoursePaletteToNative(picked));
     if (!mounted) return;
     setState(() => _overridePalette = picked);
     widget.onCoursePaletteChanged?.call(picked);

--- a/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
+++ b/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
@@ -307,14 +307,12 @@ class CourseScaffoldState extends State<CourseScaffold> {
     final CoursePaletteTheme? override = _overridePalette;
     if (override == null) return child;
     final ThemeData theme = Theme.of(context);
+    final List<ThemeExtension<dynamic>> merged = theme.extensions.values
+        .where((ThemeExtension<dynamic> ext) => ext is! CoursePaletteTheme)
+        .toList()
+      ..add(override);
     return Theme(
-      data: theme.copyWith(
-        extensions: <ThemeExtension<dynamic>>[
-          for (final ThemeExtension<dynamic> ext in theme.extensions.values)
-            if (ext is! CoursePaletteTheme) ext,
-          override,
-        ],
-      ),
+      data: theme.copyWith(extensions: merged),
       child: child,
     );
   }
@@ -1685,16 +1683,19 @@ class CourseList extends StatelessWidget {
                 context: context,
                 backgroundColor: const Color(0x00000000),
                 isScrollControlled: true,
-                builder: (BuildContext sheetCtx) => Theme(
-                  data: Theme.of(sheetCtx).copyWith(
-                    extensions: <ThemeExtension<dynamic>>[
-                      for (final ThemeExtension<dynamic> ext
-                          in Theme.of(sheetCtx).extensions.values)
-                        if (ext is! CoursePaletteTheme) ext,
-                      palette,
-                    ],
-                  ),
-                  child: CourseContent(
+                builder: (BuildContext sheetCtx) {
+                  final ThemeData sheetTheme = Theme.of(sheetCtx);
+                  final List<ThemeExtension<dynamic>> merged = sheetTheme
+                      .extensions.values
+                      .where(
+                        (ThemeExtension<dynamic> ext) =>
+                            ext is! CoursePaletteTheme,
+                      )
+                      .toList()
+                    ..add(palette);
+                  return Theme(
+                    data: sheetTheme.copyWith(extensions: merged),
+                    child: CourseContent(
                     course: course,
                     invisibleCourseCodes: invisibleCourseCodes,
                     onVisibilityChanged: (bool visible) =>
@@ -1711,8 +1712,9 @@ class CourseList extends StatelessWidget {
                         : 1,
                     courseColor: courseColor,
                     enableNotifyControl: false,
-                  ),
-                ),
+                    ),
+                  );
+                },
               );
             },
             borderRadius: BorderRadius.circular(16),

--- a/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
+++ b/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
@@ -89,6 +89,8 @@ class CourseScaffold extends StatefulWidget {
     this.customCourseData,
     this.onCustomCourseChanged,
     this.semesterPickerController,
+    this.enablePaletteSelector = true,
+    this.onCoursePaletteChanged,
   });
 
   /// Creates a [CourseScaffold] from a [DataState<CourseData>].
@@ -129,6 +131,8 @@ class CourseScaffold extends StatefulWidget {
     this.customCourseData,
     this.onCustomCourseChanged,
     this.semesterPickerController,
+    this.enablePaletteSelector = true,
+    this.onCoursePaletteChanged,
   })  : state = dataState.when(
           loading: () => CourseState.loading,
           loaded: (_, __) => CourseState.finish,
@@ -183,6 +187,17 @@ class CourseScaffold extends StatefulWidget {
   /// Optional controller for the semester picker.
   final SemesterPickerController? semesterPickerController;
 
+  /// When true (default), the setting dialog shows a palette selector
+  /// that lets the user switch between built-in [CoursePaletteTheme]s.
+  /// The choice is persisted under [CoursePaletteTheme.preferenceKey]
+  /// so it survives app restarts.
+  final bool enablePaletteSelector;
+
+  /// Called whenever the user picks a new palette from the selector.
+  /// Apps can use this to update their app-level theme extensions so
+  /// the new palette applies to other surfaces (home dashboard, etc.).
+  final ValueChanged<CoursePaletteTheme>? onCoursePaletteChanged;
+
   @override
   CourseScaffoldState createState() => CourseScaffoldState();
 }
@@ -209,12 +224,19 @@ class CourseScaffoldState extends State<CourseScaffold> {
   final Map<String, int> _courseColorIndexMap = <String, int>{};
   int _colorIndex = 0;
 
+  /// User-selected palette that overrides the app-level one for this
+  /// scaffold's subtree. `null` means "inherit from Theme".
+  CoursePaletteTheme? _overridePalette;
+
+  CoursePaletteTheme _activePalette(BuildContext context) =>
+      _overridePalette ?? CoursePaletteTheme.of(context);
+
   Color _getCourseColor(Course course) {
     final int index = _courseColorIndexMap.putIfAbsent(course.code, () {
       if (course.colorIndex != null) return course.colorIndex!;
       return _colorIndex++;
     });
-    return CoursePaletteTheme.of(context).colorAt(index);
+    return _activePalette(context).colorAt(index);
   }
 
   late ScrollController _scrollController;
@@ -237,6 +259,11 @@ class CourseScaffoldState extends State<CourseScaffold> {
       '${ApConstants.packageName}.merge_course',
       true,
     );
+    final String savedPaletteId =
+        PreferenceUtil.instance.getString(CoursePaletteTheme.preferenceKey, '');
+    if (savedPaletteId.isNotEmpty) {
+      _overridePalette = CoursePaletteTheme.fromId(savedPaletteId);
+    }
     fetchInvisibleCourseCodes();
     _scrollController = ScrollController();
     _scrollController.addListener(() {
@@ -272,9 +299,47 @@ class CourseScaffoldState extends State<CourseScaffold> {
     super.dispose();
   }
 
+  /// Wrap [child] in a [Theme] that injects [_overridePalette] as a
+  /// [CoursePaletteTheme] extension, so descendants (including modal
+  /// sheets launched via [showModalBottomSheet] with this context) see
+  /// the user-selected palette instead of the app-level one.
+  Widget _withPaletteOverride(BuildContext context, Widget child) {
+    final CoursePaletteTheme? override = _overridePalette;
+    if (override == null) return child;
+    final ThemeData theme = Theme.of(context);
+    return Theme(
+      data: theme.copyWith(
+        extensions: <ThemeExtension<dynamic>>[
+          for (final ThemeExtension<dynamic> ext in theme.extensions.values)
+            if (ext is! CoursePaletteTheme) ext,
+          override,
+        ],
+      ),
+      child: child,
+    );
+  }
+
+  Future<void> _showPalettePicker() async {
+    final CoursePaletteTheme current = _activePalette(context);
+    final CoursePaletteTheme? picked = await CoursePalettePickerSheet.show(
+      context: context,
+      currentId: current.id,
+      title: context.ap.courseColor,
+    );
+    if (picked == null || picked.id == current.id) return;
+    await PreferenceUtil.instance
+        .setString(CoursePaletteTheme.preferenceKey, picked.id);
+    if (!mounted) return;
+    setState(() => _overridePalette = picked);
+    widget.onCoursePaletteChanged?.call(picked);
+    AnalyticsUtil.instance.logEvent('course_palette_change');
+  }
+
   @override
   Widget build(BuildContext context) {
-    return CourseConfig(
+    return _withPaletteOverride(
+      context,
+      CourseConfig(
       showSectionTime: showSectionTime,
       showInstructors: showInstructors,
       showClassroomLocation: showClassroomLocation,
@@ -315,6 +380,12 @@ class CourseScaffoldState extends State<CourseScaffold> {
                 icon: Icon(ApIcon.download),
                 onPressed: _captureCourseTable,
                 tooltip: context.ap.exportCourseTable,
+              ),
+            if (widget.enablePaletteSelector)
+              IconButton(
+                icon: const Icon(Icons.palette_outlined),
+                onPressed: _showPalettePicker,
+                tooltip: context.ap.courseColor,
               ),
             IconButton(
               icon: Icon(ApIcon.settings),
@@ -471,6 +542,7 @@ class CourseScaffoldState extends State<CourseScaffold> {
             ],
           ),
         ),
+      ),
       ),
     );
   }
@@ -1035,7 +1107,9 @@ class CourseScaffoldState extends State<CourseScaffold> {
       backgroundColor: const Color(0x00000000),
       isScrollControlled: true,
       builder: (BuildContext builder) {
-        return CourseContent(
+        return _withPaletteOverride(
+          builder,
+          CourseContent(
           enableNotifyControl: widget.enableNotifyControl,
           course: course,
           notifyData: widget.notifyData,
@@ -1058,6 +1132,7 @@ class CourseScaffoldState extends State<CourseScaffold> {
             Navigator.of(builder).pop();
             _deleteCustomCourse(course);
           },
+          ),
         );
       },
     );
@@ -1610,22 +1685,33 @@ class CourseList extends StatelessWidget {
                 context: context,
                 backgroundColor: const Color(0x00000000),
                 isScrollControlled: true,
-                builder: (BuildContext context) => CourseContent(
-                  course: course,
-                  invisibleCourseCodes: invisibleCourseCodes,
-                  onVisibilityChanged: (bool visible) =>
-                      onVisibilityChanged?.call(course, visible),
-                  timeCode: timeCodes != null && timeCodes!.isNotEmpty
-                      ? timeCodes![0]
-                      : const TimeCode(
-                          title: '',
-                          startTime: '',
-                          endTime: '',
-                        ),
-                  weekday:
-                      course.times.isNotEmpty ? course.times.first.weekday : 1,
-                  courseColor: courseColor,
-                  enableNotifyControl: false,
+                builder: (BuildContext sheetCtx) => Theme(
+                  data: Theme.of(sheetCtx).copyWith(
+                    extensions: <ThemeExtension<dynamic>>[
+                      for (final ThemeExtension<dynamic> ext
+                          in Theme.of(sheetCtx).extensions.values)
+                        if (ext is! CoursePaletteTheme) ext,
+                      palette,
+                    ],
+                  ),
+                  child: CourseContent(
+                    course: course,
+                    invisibleCourseCodes: invisibleCourseCodes,
+                    onVisibilityChanged: (bool visible) =>
+                        onVisibilityChanged?.call(course, visible),
+                    timeCode: timeCodes != null && timeCodes!.isNotEmpty
+                        ? timeCodes![0]
+                        : const TimeCode(
+                            title: '',
+                            startTime: '',
+                            endTime: '',
+                          ),
+                    weekday: course.times.isNotEmpty
+                        ? course.times.first.weekday
+                        : 1,
+                    courseColor: courseColor,
+                    enableNotifyControl: false,
+                  ),
                 ),
               );
             },

--- a/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
+++ b/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
@@ -1198,6 +1198,7 @@ class CourseScaffoldState extends State<CourseScaffold> {
       existingCourses: widget.courseData.courses,
       initialWeekday: weekday,
       initialTimeIndex: timeIndex,
+      coursePalette: _activePalette(context),
     );
     if (result == null || !mounted) return;
     final CustomCourseData updated =
@@ -1212,6 +1213,7 @@ class CourseScaffoldState extends State<CourseScaffold> {
       timeCodes: widget.courseData.timeCodes,
       existingCourses: widget.courseData.courses,
       course: course,
+      coursePalette: _activePalette(context),
     );
     if (result == null || !mounted) return;
     final CustomCourseData updated =

--- a/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
+++ b/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
@@ -209,12 +209,12 @@ class CourseScaffoldState extends State<CourseScaffold> {
   final Map<String, int> _courseColorIndexMap = <String, int>{};
   int _colorIndex = 0;
 
-  Color _getCourseColor(Course course, CoursePaletteTheme palette) {
+  Color _getCourseColor(Course course) {
     final int index = _courseColorIndexMap.putIfAbsent(course.code, () {
       if (course.colorIndex != null) return course.colorIndex!;
       return _colorIndex++;
     });
-    return palette.colorAt(index);
+    return CoursePaletteTheme.of(context).colorAt(index);
   }
 
   late ScrollController _scrollController;
@@ -259,7 +259,7 @@ class CourseScaffoldState extends State<CourseScaffold> {
   void didUpdateWidget(covariant CourseScaffold oldWidget) {
     if (widget.courseData != oldWidget.courseData) {
       _buildCourseLookup();
-      _courseColorMap.clear();
+      _courseColorIndexMap.clear();
       _colorIndex = 0;
     }
     fetchInvisibleCourseCodes();
@@ -949,8 +949,7 @@ class CourseScaffoldState extends State<CourseScaffold> {
     Course course,
     int span,
   ) {
-    final CoursePaletteTheme palette = CoursePaletteTheme.of(context);
-    final Color courseColor = _getCourseColor(course, palette);
+    final Color courseColor = _getCourseColor(course);
     final String locationInfo =
         (showClassroomLocation ?? true) && course.location != null
             ? course.location.toString()
@@ -958,7 +957,7 @@ class CourseScaffoldState extends State<CourseScaffold> {
     final String instructorInfo =
         (showInstructors ?? true) ? course.getInstructors() : '';
 
-    final Color onCourseColor = palette.foregroundColor;
+    final Color onCourseColor = CoursePaletteTheme.of(context).foregroundColor;
 
     final String displayInfo = <String>[
       if (instructorInfo.isNotEmpty) instructorInfo,

--- a/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
+++ b/packages/ap_common_flutter_ui/lib/src/scaffold/course_scaffold.dart
@@ -1109,7 +1109,7 @@ class CourseScaffoldState extends State<CourseScaffold> {
         margin: const EdgeInsets.all(2),
         padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 6),
         decoration: BoxDecoration(
-          color: courseColor.withAlpha(230),
+          color: courseColor,
           borderRadius: BorderRadius.circular(8),
           boxShadow: <BoxShadow>[
             BoxShadow(

--- a/packages/ap_common_flutter_ui/lib/src/theme/course_palette_theme.dart
+++ b/packages/ap_common_flutter_ui/lib/src/theme/course_palette_theme.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+
+/// A swappable color palette for course cards.
+///
+/// Provides a fixed-length list of 12 distinct colors used by
+/// [CourseScaffold], [CourseContent], [CourseEditSheet], and the
+/// home dashboard widgets. Text drawn on top of course cards uses
+/// [foregroundColor] directly — it does **not** vary per card based
+/// on luminance, so every card in the same palette has the same
+/// readable text color.
+///
+/// Apps inject a palette via [ThemeData.extensions]:
+///
+/// ```dart
+/// MaterialApp(
+///   theme: ThemeData.light().copyWith(
+///     extensions: <ThemeExtension<dynamic>>[
+///       CoursePaletteTheme.appleSystem,
+///     ],
+///   ),
+/// );
+/// ```
+///
+/// Or via [ApApp] / [ApTheme] which accept a [coursePalette] argument.
+@immutable
+class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
+  const CoursePaletteTheme({
+    required this.id,
+    required this.colors,
+    required this.foregroundColor,
+  }) : assert(
+          colors.length == paletteLength,
+          'CoursePaletteTheme.colors must have exactly $paletteLength '
+          'entries so existing Course.colorIndex values stay stable.',
+        );
+
+  /// The expected length of [colors]. All built-in palettes honor this.
+  static const int paletteLength = 12;
+
+  /// A stable identifier, useful for persisting the active palette
+  /// or bridging to native widgets via SharedPreferences.
+  final String id;
+
+  /// The 12 course colors.
+  final List<Color> colors;
+
+  /// Text / icon color drawn on top of any course card.
+  final Color foregroundColor;
+
+  /// Resolve the palette from [BuildContext], falling back to
+  /// [material] when no [CoursePaletteTheme] is registered.
+  static CoursePaletteTheme of(BuildContext context) {
+    return Theme.of(context).extension<CoursePaletteTheme>() ?? material;
+  }
+
+  /// Pick the color at [index], wrapping around if out of range.
+  Color colorAt(int index) => colors[index.abs() % colors.length];
+
+  /// Material Design 400 shade — matches the legacy `courseColors`
+  /// constant, so existing `Course.colorIndex` values keep the same
+  /// visual when no palette is injected.
+  static const CoursePaletteTheme material = CoursePaletteTheme(
+    id: 'material400',
+    colors: <Color>[
+      Color(0xFF5C6BC0), // Indigo
+      Color(0xFF26A69A), // Teal
+      Color(0xFFEF5350), // Red
+      Color(0xFFAB47BC), // Purple
+      Color(0xFF42A5F5), // Blue
+      Color(0xFFFF7043), // Deep Orange
+      Color(0xFF66BB6A), // Green
+      Color(0xFFFFCA28), // Amber
+      Color(0xFF8D6E63), // Brown
+      Color(0xFF78909C), // Blue Grey
+      Color(0xFFEC407A), // Pink
+      Color(0xFF7E57C2), // Deep Purple
+    ],
+    foregroundColor: Colors.white,
+  );
+
+  /// iOS System Colors (light variant) — higher saturation, feels
+  /// native on Apple platforms.
+  static const CoursePaletteTheme appleSystem = CoursePaletteTheme(
+    id: 'appleSystem',
+    colors: <Color>[
+      Color(0xFFFF3B30), // Red
+      Color(0xFFFF9500), // Orange
+      Color(0xFFFFCC00), // Yellow
+      Color(0xFF34C759), // Green
+      Color(0xFF00C7BE), // Mint
+      Color(0xFF30B0C7), // Teal
+      Color(0xFF32ADE6), // Cyan
+      Color(0xFF007AFF), // Blue
+      Color(0xFF5856D6), // Indigo
+      Color(0xFFAF52DE), // Purple
+      Color(0xFFFF2D55), // Pink
+      Color(0xFFA2845E), // Brown
+    ],
+    foregroundColor: Colors.white,
+  );
+
+  /// Muted pastel palette inspired by Google Calendar — softer on
+  /// the eyes for long-form schedule reading.
+  static const CoursePaletteTheme pastel = CoursePaletteTheme(
+    id: 'pastel',
+    colors: <Color>[
+      Color(0xFFD94F4C), // Tomato
+      Color(0xFFE68C3E), // Tangerine
+      Color(0xFFCBA84A), // Banana
+      Color(0xFF7EB26D), // Sage
+      Color(0xFF3E8B5B), // Basil
+      Color(0xFF4A9DBF), // Peacock
+      Color(0xFF5A7CC9), // Blueberry
+      Color(0xFF8589C8), // Lavender
+      Color(0xFF8A4A95), // Grape
+      Color(0xFFE07C7C), // Flamingo
+      Color(0xFF7D7D7D), // Graphite
+      Color(0xFFA6786A), // Cocoa
+    ],
+    foregroundColor: Colors.white,
+  );
+
+  /// All built-in palettes, in display order.
+  static const List<CoursePaletteTheme> builtIn = <CoursePaletteTheme>[
+    material,
+    appleSystem,
+    pastel,
+  ];
+
+  @override
+  CoursePaletteTheme copyWith({
+    String? id,
+    List<Color>? colors,
+    Color? foregroundColor,
+  }) {
+    return CoursePaletteTheme(
+      id: id ?? this.id,
+      colors: colors ?? this.colors,
+      foregroundColor: foregroundColor ?? this.foregroundColor,
+    );
+  }
+
+  @override
+  CoursePaletteTheme lerp(CoursePaletteTheme? other, double t) {
+    if (other == null) return this;
+    // Palettes always have the same length (paletteLength).
+    final List<Color> lerped = <Color>[
+      for (int i = 0; i < colors.length; i++)
+        Color.lerp(colors[i], other.colors[i], t) ?? colors[i],
+    ];
+    return CoursePaletteTheme(
+      id: t < 0.5 ? id : other.id,
+      colors: lerped,
+      foregroundColor:
+          Color.lerp(foregroundColor, other.foregroundColor, t) ??
+              foregroundColor,
+    );
+  }
+}

--- a/packages/ap_common_flutter_ui/lib/src/theme/course_palette_theme.dart
+++ b/packages/ap_common_flutter_ui/lib/src/theme/course_palette_theme.dart
@@ -168,6 +168,72 @@ class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
     foregroundColor: Colors.white,
   );
 
+  /// Material Design 600 shade — punchier, higher-contrast cousin of
+  /// [material] that works well on light backgrounds.
+  static const CoursePaletteTheme materialBold = CoursePaletteTheme(
+    id: 'materialBold',
+    name: 'Material Bold',
+    colors: <Color>[
+      Color(0xFF3949AB), // Indigo 600
+      Color(0xFF00897B), // Teal 600
+      Color(0xFFE53935), // Red 600
+      Color(0xFF8E24AA), // Purple 600
+      Color(0xFF1E88E5), // Blue 600
+      Color(0xFFF4511E), // Deep Orange 600
+      Color(0xFF43A047), // Green 600
+      Color(0xFFFFB300), // Amber 600
+      Color(0xFF6D4C41), // Brown 600
+      Color(0xFF546E7A), // Blue Grey 600
+      Color(0xFFD81B60), // Pink 600
+      Color(0xFF5E35B1), // Deep Purple 600
+    ],
+    foregroundColor: Colors.white,
+  );
+
+  /// Nord — the popular cool-toned designer palette. Uses a black
+  /// foreground because several Nord colors are pale.
+  static const CoursePaletteTheme nord = CoursePaletteTheme(
+    id: 'nord',
+    name: 'Nord',
+    colors: <Color>[
+      Color(0xFFBF616A), // nord11 red
+      Color(0xFFD08770), // nord12 orange
+      Color(0xFFEBCB8B), // nord13 yellow
+      Color(0xFFA3BE8C), // nord14 green
+      Color(0xFF8FBCBB), // nord7 mint
+      Color(0xFF88C0D0), // nord8 cyan
+      Color(0xFF81A1C1), // nord9 light blue
+      Color(0xFF5E81AC), // nord10 deep blue
+      Color(0xFFB48EAD), // nord15 purple
+      Color(0xFF4C566A), // nord3 slate
+      Color(0xFFD8A8C0), // soft pink (Nord-flavored)
+      Color(0xFF9E8A76), // warm brown (Nord-flavored)
+    ],
+    foregroundColor: Colors.black,
+  );
+
+  /// Vibrant — high-saturation Material Accent (A400 / A700) selection
+  /// for users who want bold, energetic course cards.
+  static const CoursePaletteTheme vibrant = CoursePaletteTheme(
+    id: 'vibrant',
+    name: 'Vibrant',
+    colors: <Color>[
+      Color(0xFFFF1744), // Red A400
+      Color(0xFFFF3D00), // Deep Orange A400
+      Color(0xFFFF9100), // Orange A400
+      Color(0xFFFFD600), // Yellow A700
+      Color(0xFF00C853), // Green A700
+      Color(0xFF1DE9B6), // Teal A400
+      Color(0xFF00B0FF), // Light Blue A400
+      Color(0xFF2962FF), // Blue A700
+      Color(0xFF304FFE), // Indigo A700
+      Color(0xFF6200EA), // Deep Purple A700
+      Color(0xFFAA00FF), // Purple A700
+      Color(0xFFC51162), // Pink A700
+    ],
+    foregroundColor: Colors.white,
+  );
+
   /// Muted pastel palette inspired by Google Calendar — softer on
   /// the eyes for long-form schedule reading.
   static const CoursePaletteTheme pastel = CoursePaletteTheme(
@@ -195,7 +261,10 @@ class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
   /// the [dark] field on their light parent.
   static const List<CoursePaletteTheme> builtIn = <CoursePaletteTheme>[
     material,
+    materialBold,
     appleSystem,
+    nord,
+    vibrant,
     pastel,
   ];
 

--- a/packages/ap_common_flutter_ui/lib/src/theme/course_palette_theme.dart
+++ b/packages/ap_common_flutter_ui/lib/src/theme/course_palette_theme.dart
@@ -167,8 +167,9 @@ class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
     if (other == null) return this;
     // Both palettes are expected to be length [paletteLength] — use the
     // shorter of the two as a safety net if a custom palette violates that.
-    final int len =
-        colors.length < other.colors.length ? colors.length : other.colors.length;
+    final int len = colors.length < other.colors.length
+        ? colors.length
+        : other.colors.length;
     final List<Color> lerped = <Color>[
       for (int i = 0; i < len; i++)
         Color.lerp(colors[i], other.colors[i], t) ?? colors[i],

--- a/packages/ap_common_flutter_ui/lib/src/theme/course_palette_theme.dart
+++ b/packages/ap_common_flutter_ui/lib/src/theme/course_palette_theme.dart
@@ -26,6 +26,7 @@ import 'package:flutter/material.dart';
 class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
   const CoursePaletteTheme({
     required this.id,
+    required this.name,
     required this.colors,
     required this.foregroundColor,
   });
@@ -36,9 +37,16 @@ class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
   /// [colorAt] wraps with modulo so a shorter list still renders.
   static const int paletteLength = 12;
 
+  /// Preference key used by [CourseScaffold]'s built-in palette picker
+  /// to persist the user's choice across app launches.
+  static const String preferenceKey = 'ap_common.course_palette_id';
+
   /// A stable identifier, useful for persisting the active palette
   /// or bridging to native widgets via SharedPreferences.
   final String id;
+
+  /// Human-readable display name shown in palette pickers.
+  final String name;
 
   /// The 12 course colors.
   final List<Color> colors;
@@ -52,6 +60,16 @@ class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
     return Theme.of(context).extension<CoursePaletteTheme>() ?? material;
   }
 
+  /// Look up a built-in palette by [id]. Returns [material] if no
+  /// match, so callers can safely pass persisted ids that may have
+  /// been removed between app versions.
+  static CoursePaletteTheme fromId(String? id) {
+    for (final CoursePaletteTheme p in builtIn) {
+      if (p.id == id) return p;
+    }
+    return material;
+  }
+
   /// Pick the color at [index], wrapping around if out of range.
   Color colorAt(int index) => colors[index.abs() % colors.length];
 
@@ -60,6 +78,7 @@ class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
   /// visual when no palette is injected.
   static const CoursePaletteTheme material = CoursePaletteTheme(
     id: 'material400',
+    name: 'Material',
     colors: <Color>[
       Color(0xFF5C6BC0), // Indigo
       Color(0xFF26A69A), // Teal
@@ -81,6 +100,7 @@ class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
   /// native on Apple platforms.
   static const CoursePaletteTheme appleSystem = CoursePaletteTheme(
     id: 'appleSystem',
+    name: 'Apple System',
     colors: <Color>[
       Color(0xFFFF3B30), // Red
       Color(0xFFFF9500), // Orange
@@ -102,6 +122,7 @@ class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
   /// the eyes for long-form schedule reading.
   static const CoursePaletteTheme pastel = CoursePaletteTheme(
     id: 'pastel',
+    name: 'Pastel',
     colors: <Color>[
       Color(0xFFD94F4C), // Tomato
       Color(0xFFE68C3E), // Tangerine
@@ -129,11 +150,13 @@ class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
   @override
   CoursePaletteTheme copyWith({
     String? id,
+    String? name,
     List<Color>? colors,
     Color? foregroundColor,
   }) {
     return CoursePaletteTheme(
       id: id ?? this.id,
+      name: name ?? this.name,
       colors: colors ?? this.colors,
       foregroundColor: foregroundColor ?? this.foregroundColor,
     );
@@ -142,13 +165,18 @@ class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
   @override
   CoursePaletteTheme lerp(CoursePaletteTheme? other, double t) {
     if (other == null) return this;
-    // Palettes always have the same length (paletteLength).
+    // Both palettes are expected to be length [paletteLength] — use the
+    // shorter of the two as a safety net if a custom palette violates that.
+    final int len =
+        colors.length < other.colors.length ? colors.length : other.colors.length;
     final List<Color> lerped = <Color>[
-      for (int i = 0; i < colors.length; i++)
+      for (int i = 0; i < len; i++)
         Color.lerp(colors[i], other.colors[i], t) ?? colors[i],
     ];
+    final bool pickOther = t >= 0.5;
     return CoursePaletteTheme(
-      id: t < 0.5 ? id : other.id,
+      id: pickOther ? other.id : id,
+      name: pickOther ? other.name : name,
       colors: lerped,
       foregroundColor:
           Color.lerp(foregroundColor, other.foregroundColor, t) ??

--- a/packages/ap_common_flutter_ui/lib/src/theme/course_palette_theme.dart
+++ b/packages/ap_common_flutter_ui/lib/src/theme/course_palette_theme.dart
@@ -42,6 +42,11 @@ class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
   /// [colorAt] wraps with modulo so a shorter list still renders.
   static const int paletteLength = 12;
 
+  /// Alpha applied to the rendered course card background. The color
+  /// picker in `CourseEditSheet` applies the same alpha to its preview
+  /// swatches so "what you pick" matches "what you see" on the table.
+  static const int cardAlpha = 230;
+
   /// Preference key used by [CourseScaffold]'s built-in palette picker
   /// to persist the user's choice across app launches.
   static const String preferenceKey = 'ap_common.course_palette_id';

--- a/packages/ap_common_flutter_ui/lib/src/theme/course_palette_theme.dart
+++ b/packages/ap_common_flutter_ui/lib/src/theme/course_palette_theme.dart
@@ -28,13 +28,12 @@ class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
     required this.id,
     required this.colors,
     required this.foregroundColor,
-  }) : assert(
-          colors.length == paletteLength,
-          'CoursePaletteTheme.colors must have exactly $paletteLength '
-          'entries so existing Course.colorIndex values stay stable.',
-        );
+  });
 
-  /// The expected length of [colors]. All built-in palettes honor this.
+  /// The expected length of [colors]. All built-in palettes honor this
+  /// so existing `Course.colorIndex` values stay visually stable when
+  /// apps swap palettes. Custom palettes should match this length, but
+  /// [colorAt] wraps with modulo so a shorter list still renders.
   static const int paletteLength = 12;
 
   /// A stable identifier, useful for persisting the active palette

--- a/packages/ap_common_flutter_ui/lib/src/theme/course_palette_theme.dart
+++ b/packages/ap_common_flutter_ui/lib/src/theme/course_palette_theme.dart
@@ -22,6 +22,10 @@ import 'package:flutter/material.dart';
 /// ```
 ///
 /// Or via [ApApp] / [ApTheme] which accept a [coursePalette] argument.
+///
+/// Palettes can carry an optional [dark] counterpart. When the app is
+/// rendered in [Brightness.dark], [of] auto-resolves to that variant so
+/// apps only need to register the light palette once.
 @immutable
 class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
   const CoursePaletteTheme({
@@ -29,6 +33,7 @@ class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
     required this.name,
     required this.colors,
     required this.foregroundColor,
+    this.dark,
   });
 
   /// The expected length of [colors]. All built-in palettes honor this
@@ -54,10 +59,19 @@ class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
   /// Text / icon color drawn on top of any course card.
   final Color foregroundColor;
 
+  /// Optional dark-mode counterpart. When provided and the ambient
+  /// [Brightness] is dark, [of] / [resolvedFor] return this variant
+  /// instead of the light colors. The dark variant itself should not
+  /// set [dark] — only the light palette does.
+  final CoursePaletteTheme? dark;
+
   /// Resolve the palette from [BuildContext], falling back to
-  /// [material] when no [CoursePaletteTheme] is registered.
+  /// [material] when no [CoursePaletteTheme] is registered. Honors the
+  /// ambient [Brightness] by returning the [dark] variant when set.
   static CoursePaletteTheme of(BuildContext context) {
-    return Theme.of(context).extension<CoursePaletteTheme>() ?? material;
+    final CoursePaletteTheme ext =
+        Theme.of(context).extension<CoursePaletteTheme>() ?? material;
+    return ext.resolvedFor(context);
   }
 
   /// Look up a built-in palette by [id]. Returns [material] if no
@@ -68,6 +82,17 @@ class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
       if (p.id == id) return p;
     }
     return material;
+  }
+
+  /// Return [dark] when the ambient brightness is dark and a dark
+  /// variant exists; otherwise return this palette unchanged.
+  CoursePaletteTheme resolvedFor(BuildContext context) {
+    final CoursePaletteTheme? darkVariant = dark;
+    if (darkVariant != null &&
+        Theme.of(context).brightness == Brightness.dark) {
+      return darkVariant;
+    }
+    return this;
   }
 
   /// Pick the color at [index], wrapping around if out of range.
@@ -97,7 +122,8 @@ class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
   );
 
   /// iOS System Colors (light variant) — higher saturation, feels
-  /// native on Apple platforms.
+  /// native on Apple platforms. Pairs with [_appleSystemDark] in dark
+  /// mode via the [dark] field.
   static const CoursePaletteTheme appleSystem = CoursePaletteTheme(
     id: 'appleSystem',
     name: 'Apple System',
@@ -114,6 +140,30 @@ class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
       Color(0xFFAF52DE), // Purple
       Color(0xFFFF2D55), // Pink
       Color(0xFFA2845E), // Brown
+    ],
+    foregroundColor: Colors.white,
+    dark: _appleSystemDark,
+  );
+
+  /// iOS System Colors dark-mode hex values (stable from iOS 13
+  /// through iOS 26). Registered as the [dark] counterpart of
+  /// [appleSystem]; not meant to be used on its own.
+  static const CoursePaletteTheme _appleSystemDark = CoursePaletteTheme(
+    id: 'appleSystemDark',
+    name: 'Apple System (Dark)',
+    colors: <Color>[
+      Color(0xFFFF453A), // Red
+      Color(0xFFFF9F0A), // Orange
+      Color(0xFFFFD60A), // Yellow
+      Color(0xFF30D158), // Green
+      Color(0xFF63E6E2), // Mint
+      Color(0xFF40CBE0), // Teal
+      Color(0xFF64D2FF), // Cyan
+      Color(0xFF0A84FF), // Blue
+      Color(0xFF5E5CE6), // Indigo
+      Color(0xFFBF5AF2), // Purple
+      Color(0xFFFF375F), // Pink
+      Color(0xFFAC8E68), // Brown
     ],
     foregroundColor: Colors.white,
   );
@@ -140,7 +190,9 @@ class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
     foregroundColor: Colors.white,
   );
 
-  /// All built-in palettes, in display order.
+  /// All built-in palettes shown in pickers, in display order. Dark
+  /// variants are intentionally omitted — they are surfaced only via
+  /// the [dark] field on their light parent.
   static const List<CoursePaletteTheme> builtIn = <CoursePaletteTheme>[
     material,
     appleSystem,
@@ -153,12 +205,14 @@ class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
     String? name,
     List<Color>? colors,
     Color? foregroundColor,
+    CoursePaletteTheme? dark,
   }) {
     return CoursePaletteTheme(
       id: id ?? this.id,
       name: name ?? this.name,
       colors: colors ?? this.colors,
       foregroundColor: foregroundColor ?? this.foregroundColor,
+      dark: dark ?? this.dark,
     );
   }
 
@@ -182,6 +236,7 @@ class CoursePaletteTheme extends ThemeExtension<CoursePaletteTheme> {
       foregroundColor:
           Color.lerp(foregroundColor, other.foregroundColor, t) ??
               foregroundColor,
+      dark: pickOther ? other.dark : dark,
     );
   }
 }

--- a/packages/ap_common_flutter_ui/lib/src/widgets/course_edit_sheet.dart
+++ b/packages/ap_common_flutter_ui/lib/src/widgets/course_edit_sheet.dart
@@ -356,7 +356,8 @@ class _CourseEditSheetState extends State<CourseEditSheet> {
               width: 36,
               height: 36,
               decoration: BoxDecoration(
-                color: palette.colors[i],
+                color: palette.colors[i]
+                    .withAlpha(CoursePaletteTheme.cardAlpha),
                 shape: BoxShape.circle,
                 border: selected
                     ? Border.all(

--- a/packages/ap_common_flutter_ui/lib/src/widgets/course_edit_sheet.dart
+++ b/packages/ap_common_flutter_ui/lib/src/widgets/course_edit_sheet.dart
@@ -72,7 +72,7 @@ class _CourseEditSheetState extends State<CourseEditSheet> {
   /// Selected time slots: set of (weekday, timeIndex) pairs.
   final Set<(int, int)> _selectedSlots = <(int, int)>{};
 
-  /// Selected color index into [courseColors].
+  /// Selected color index into the active [CoursePaletteTheme].
   int _colorIndex = 0;
 
   /// Lookup: (weekday, timeIndex) → course title, for conflict
@@ -98,7 +98,7 @@ class _CourseEditSheetState extends State<CourseEditSheet> {
         _selectedSlots.add((t.weekday, t.index));
       }
       _colorIndex = c.colorIndex ??
-          c.code.hashCode.abs() % courseColors.length;
+          c.code.hashCode.abs() % CoursePaletteTheme.paletteLength;
     } else if (widget.initialWeekday != null &&
         widget.initialTimeIndex != null) {
       _selectedSlots.add(
@@ -317,11 +317,12 @@ class _CourseEditSheetState extends State<CourseEditSheet> {
   }
 
   Widget _buildColorPicker(ColorScheme colorScheme) {
+    final CoursePaletteTheme palette = CoursePaletteTheme.of(context);
     return Wrap(
       spacing: 10,
       runSpacing: 10,
       children: List<Widget>.generate(
-        courseColors.length,
+        palette.colors.length,
         (int i) {
           final bool selected = i == _colorIndex;
           return GestureDetector(
@@ -330,7 +331,7 @@ class _CourseEditSheetState extends State<CourseEditSheet> {
               width: 36,
               height: 36,
               decoration: BoxDecoration(
-                color: courseColors[i],
+                color: palette.colors[i],
                 shape: BoxShape.circle,
                 border: selected
                     ? Border.all(
@@ -340,9 +341,9 @@ class _CourseEditSheetState extends State<CourseEditSheet> {
                     : null,
               ),
               child: selected
-                  ? const Icon(
+                  ? Icon(
                       Icons.check,
-                      color: Colors.white,
+                      color: palette.foregroundColor,
                       size: 20,
                     )
                   : null,
@@ -445,9 +446,10 @@ class _CourseEditSheetState extends State<CourseEditSheet> {
     final String? occupiedBy = _occupiedSlots[key];
     final bool isOccupied = occupiedBy != null;
 
+    final CoursePaletteTheme palette = CoursePaletteTheme.of(context);
     Color bg;
     if (isSelected) {
-      bg = courseColors[_colorIndex].withAlpha(179);
+      bg = palette.colorAt(_colorIndex).withAlpha(179);
     } else if (isOccupied) {
       bg = colorScheme.surfaceContainerHighest;
     } else {
@@ -477,10 +479,10 @@ class _CourseEditSheetState extends State<CourseEditSheet> {
         height: 36,
         color: bg,
         child: isSelected
-            ? const Icon(
+            ? Icon(
                 Icons.check_rounded,
                 size: 16,
-                color: Colors.white,
+                color: palette.foregroundColor,
               )
             : isOccupied
                 ? Center(

--- a/packages/ap_common_flutter_ui/lib/src/widgets/course_edit_sheet.dart
+++ b/packages/ap_common_flutter_ui/lib/src/widgets/course_edit_sheet.dart
@@ -34,6 +34,13 @@ class CourseEditSheet extends StatefulWidget {
   bool get isEditing => course != null;
 
   /// Show this sheet as a modal bottom sheet.
+  ///
+  /// The sheet opens via the root navigator, so any
+  /// [CoursePaletteTheme] override installed locally on the caller's
+  /// subtree (e.g. via [CourseScaffold]'s palette picker) is not
+  /// inherited. To keep the color picker consistent with the
+  /// surrounding scaffold, capture the palette from [context] up front
+  /// and re-inject it into the sheet's builder.
   static Future<Course?> show({
     required BuildContext context,
     required List<TimeCode> timeCodes,
@@ -42,17 +49,35 @@ class CourseEditSheet extends StatefulWidget {
     int? initialWeekday,
     int? initialTimeIndex,
   }) {
+    final CoursePaletteTheme? palette =
+        Theme.of(context).extension<CoursePaletteTheme>();
     return showModalBottomSheet<Course>(
       context: context,
       isScrollControlled: true,
       useSafeArea: true,
-      builder: (_) => CourseEditSheet(
-        timeCodes: timeCodes,
-        existingCourses: existingCourses,
-        course: course,
-        initialWeekday: initialWeekday,
-        initialTimeIndex: initialTimeIndex,
-      ),
+      builder: (BuildContext sheetCtx) {
+        final CourseEditSheet sheet = CourseEditSheet(
+          timeCodes: timeCodes,
+          existingCourses: existingCourses,
+          course: course,
+          initialWeekday: initialWeekday,
+          initialTimeIndex: initialTimeIndex,
+        );
+        if (palette == null) return sheet;
+        final ThemeData sheetTheme = Theme.of(sheetCtx);
+        final List<ThemeExtension<dynamic>> merged = sheetTheme
+            .extensions.values
+            .where(
+              (ThemeExtension<dynamic> ext) =>
+                  ext is! CoursePaletteTheme,
+            )
+            .toList()
+          ..add(palette);
+        return Theme(
+          data: sheetTheme.copyWith(extensions: merged),
+          child: sheet,
+        );
+      },
     );
   }
 

--- a/packages/ap_common_flutter_ui/lib/src/widgets/course_edit_sheet.dart
+++ b/packages/ap_common_flutter_ui/lib/src/widgets/course_edit_sheet.dart
@@ -38,9 +38,9 @@ class CourseEditSheet extends StatefulWidget {
   /// The sheet opens via the root navigator, so any
   /// [CoursePaletteTheme] override installed locally on the caller's
   /// subtree (e.g. via [CourseScaffold]'s palette picker) is not
-  /// inherited. To keep the color picker consistent with the
-  /// surrounding scaffold, capture the palette from [context] up front
-  /// and re-inject it into the sheet's builder.
+  /// inherited. Pass [coursePalette] explicitly so the color picker
+  /// stays in sync with the surrounding scaffold; when omitted, the
+  /// sheet falls back to the palette resolved from [context].
   static Future<Course?> show({
     required BuildContext context,
     required List<TimeCode> timeCodes,
@@ -48,8 +48,9 @@ class CourseEditSheet extends StatefulWidget {
     Course? course,
     int? initialWeekday,
     int? initialTimeIndex,
+    CoursePaletteTheme? coursePalette,
   }) {
-    final CoursePaletteTheme? palette =
+    final CoursePaletteTheme? palette = coursePalette ??
         Theme.of(context).extension<CoursePaletteTheme>();
     return showModalBottomSheet<Course>(
       context: context,

--- a/packages/ap_common_flutter_ui/lib/src/widgets/course_palette_picker_sheet.dart
+++ b/packages/ap_common_flutter_ui/lib/src/widgets/course_palette_picker_sheet.dart
@@ -1,0 +1,161 @@
+import 'package:ap_common_flutter_ui/src/theme/course_palette_theme.dart';
+import 'package:flutter/material.dart';
+
+/// Bottom sheet that lets the user pick from a list of course
+/// palettes. Shows a 12-dot preview per palette so the user can see
+/// the full color range before committing.
+///
+/// Call [show] to present the sheet; the resolved [Future] yields the
+/// chosen palette, or `null` if dismissed.
+class CoursePalettePickerSheet extends StatelessWidget {
+  const CoursePalettePickerSheet({
+    super.key,
+    required this.palettes,
+    required this.currentId,
+    this.title,
+  });
+
+  /// Palettes to display. Defaults to [CoursePaletteTheme.builtIn] via
+  /// the [show] helper.
+  final List<CoursePaletteTheme> palettes;
+
+  /// Id of the currently active palette, used to mark the row as
+  /// selected.
+  final String currentId;
+
+  /// Sheet title. Defaults to "Course palette" when omitted.
+  final String? title;
+
+  static Future<CoursePaletteTheme?> show({
+    required BuildContext context,
+    required String currentId,
+    List<CoursePaletteTheme>? palettes,
+    String? title,
+  }) {
+    return showModalBottomSheet<CoursePaletteTheme>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (_) => CoursePalettePickerSheet(
+        palettes: palettes ?? CoursePaletteTheme.builtIn,
+        currentId: currentId,
+        title: title,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 12),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            _buildHandle(colorScheme),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 8, 20, 12),
+              child: Text(
+                title ?? 'Course palette',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w600,
+                  color: colorScheme.onSurface,
+                ),
+              ),
+            ),
+            for (final CoursePaletteTheme palette in palettes)
+              _PaletteRow(
+                palette: palette,
+                selected: palette.id == currentId,
+                onTap: () => Navigator.of(context).pop(palette),
+              ),
+            const SizedBox(height: 8),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHandle(ColorScheme colorScheme) {
+    return Center(
+      child: Container(
+        width: 40,
+        height: 4,
+        margin: const EdgeInsets.symmetric(vertical: 4),
+        decoration: BoxDecoration(
+          color: colorScheme.onSurfaceVariant.withAlpha(77),
+          borderRadius: BorderRadius.circular(2),
+        ),
+      ),
+    );
+  }
+}
+
+class _PaletteRow extends StatelessWidget {
+  const _PaletteRow({
+    required this.palette,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final CoursePaletteTheme palette;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: Text(
+                    palette.name,
+                    style: TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                      color: colorScheme.onSurface,
+                    ),
+                  ),
+                ),
+                if (selected)
+                  Icon(
+                    Icons.check_rounded,
+                    size: 20,
+                    color: colorScheme.primary,
+                  ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 6,
+              runSpacing: 6,
+              children: <Widget>[
+                for (final Color color in palette.colors)
+                  Container(
+                    width: 20,
+                    height: 20,
+                    decoration: BoxDecoration(
+                      color: color,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/ap_common_flutter_ui/lib/src/widgets/course_palette_picker_sheet.dart
+++ b/packages/ap_common_flutter_ui/lib/src/widgets/course_palette_picker_sheet.dart
@@ -95,6 +95,77 @@ class CoursePalettePickerSheet extends StatelessWidget {
   }
 }
 
+class _ModeBadge extends StatelessWidget {
+  const _ModeBadge({required this.label, required this.colorScheme});
+
+  final String label;
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: colorScheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 10,
+          fontWeight: FontWeight.w600,
+          color: colorScheme.onSecondaryContainer,
+        ),
+      ),
+    );
+  }
+}
+
+class _SwatchRow extends StatelessWidget {
+  const _SwatchRow({required this.colors, required this.label});
+
+  final List<Color> colors;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: <Widget>[
+        SizedBox(
+          width: 36,
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w500,
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: <Widget>[
+              for (final Color color in colors)
+                Container(
+                  width: 18,
+                  height: 18,
+                  decoration: BoxDecoration(
+                    color: color,
+                    shape: BoxShape.circle,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
 class _PaletteRow extends StatelessWidget {
   const _PaletteRow({
     required this.palette,
@@ -109,6 +180,7 @@ class _PaletteRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final CoursePaletteTheme? darkVariant = palette.dark;
 
     return InkWell(
       onTap: onTap,
@@ -129,30 +201,24 @@ class _PaletteRow extends StatelessWidget {
                     ),
                   ),
                 ),
-                if (selected)
+                if (darkVariant != null)
+                  _ModeBadge(label: 'Auto dark', colorScheme: colorScheme),
+                if (selected) ...<Widget>[
+                  const SizedBox(width: 6),
                   Icon(
                     Icons.check_rounded,
                     size: 20,
                     color: colorScheme.primary,
                   ),
+                ],
               ],
             ),
             const SizedBox(height: 8),
-            Wrap(
-              spacing: 6,
-              runSpacing: 6,
-              children: <Widget>[
-                for (final Color color in palette.colors)
-                  Container(
-                    width: 20,
-                    height: 20,
-                    decoration: BoxDecoration(
-                      color: color,
-                      shape: BoxShape.circle,
-                    ),
-                  ),
-              ],
-            ),
+            _SwatchRow(colors: palette.colors, label: 'Light'),
+            if (darkVariant != null) ...<Widget>[
+              const SizedBox(height: 6),
+              _SwatchRow(colors: darkVariant.colors, label: 'Dark'),
+            ],
           ],
         ),
       ),

--- a/packages/ap_common_flutter_ui/lib/src/widgets/course_palette_picker_sheet.dart
+++ b/packages/ap_common_flutter_ui/lib/src/widgets/course_palette_picker_sheet.dart
@@ -131,7 +131,6 @@ class _SwatchRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
     return Row(
-      crossAxisAlignment: CrossAxisAlignment.center,
       children: <Widget>[
         SizedBox(
           width: 36,

--- a/packages/ap_common_flutter_ui/lib/src/widgets/home_dashboard_widgets.dart
+++ b/packages/ap_common_flutter_ui/lib/src/widgets/home_dashboard_widgets.dart
@@ -160,6 +160,7 @@ class TodayScheduleCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final CoursePaletteTheme palette = CoursePaletteTheme.of(context);
     final int todayWeekday = DateTime.now().weekday;
     final int tomorrowWeekday = todayWeekday == 7 ? 1 : todayWeekday + 1;
     List<_TodayItem> items = _getItemsForWeekday(todayWeekday);
@@ -219,7 +220,7 @@ class TodayScheduleCard extends StatelessWidget {
               for (int i = 0;
                   i < items.length && i < maxItems;
                   i++) ...<Widget>[
-                _buildRow(colorScheme, items[i]),
+                _buildRow(colorScheme, palette, items[i]),
                 if (i < items.length - 1 && i < maxItems - 1)
                   const SizedBox(height: 8),
               ],
@@ -242,8 +243,12 @@ class TodayScheduleCard extends StatelessWidget {
     );
   }
 
-  Widget _buildRow(ColorScheme colorScheme, _TodayItem item) {
-    final Color barColor = courseColors[item.colorIndex % courseColors.length];
+  Widget _buildRow(
+    ColorScheme colorScheme,
+    CoursePaletteTheme palette,
+    _TodayItem item,
+  ) {
+    final Color barColor = palette.colorAt(item.colorIndex);
     final DateTime now = DateTime.now();
     final bool isPast = item.endMinutes < now.hour * 60 + now.minute;
 

--- a/packages/ap_common_plugin/android/src/main/kotlin/me/rainvisitor/ap_common_plugin/ApCommonPlugin.kt
+++ b/packages/ap_common_plugin/android/src/main/kotlin/me/rainvisitor/ap_common_plugin/ApCommonPlugin.kt
@@ -22,6 +22,14 @@ class ApCommonPlugin : FlutterPlugin, MethodCallHandler {
     companion object {
         const val PREF_NAME = "ap_common_plugin"
         const val KEY_COURSE_NOTIFY = "course_notify"
+        const val KEY_COURSE_PALETTE_ID = "course_palette_id"
+        const val KEY_COURSE_PALETTE_COLORS = "course_palette_colors"
+        const val KEY_COURSE_PALETTE_FOREGROUND =
+            "course_palette_foreground"
+        const val KEY_COURSE_PALETTE_DARK_COLORS =
+            "course_palette_dark_colors"
+        const val KEY_COURSE_PALETTE_DARK_FOREGROUND =
+            "course_palette_dark_foreground"
     }
 
     override fun onAttachedToEngine(
@@ -80,6 +88,64 @@ class ApCommonPlugin : FlutterPlugin, MethodCallHandler {
                 scope.launch {
                     StudentIdWidget().updateAll(context)
                 }
+                result.success(null)
+            }
+            "setCoursePalette" -> {
+                val args = call.arguments as? Map<*, *>
+                if (args == null) {
+                    result.error(
+                        "INVALID_ARGUMENT",
+                        "Palette arguments are required",
+                        null,
+                    )
+                    return
+                }
+                val id = args["id"] as? String
+                val colors = args["colors"] as? List<*>
+                val foreground = (args["foregroundColor"] as? Number)?.toLong()
+                if (id == null || colors == null || foreground == null) {
+                    result.error(
+                        "INVALID_ARGUMENT",
+                        "id, colors, foregroundColor are required",
+                        null,
+                    )
+                    return
+                }
+                val prefs = context.getSharedPreferences(
+                    PREF_NAME,
+                    Context.MODE_PRIVATE,
+                )
+                val editor = prefs.edit()
+                    .putString(KEY_COURSE_PALETTE_ID, id)
+                    .putString(
+                        KEY_COURSE_PALETTE_COLORS,
+                        colors.joinToString(",") {
+                            ((it as? Number)?.toLong() ?: 0L).toString()
+                        },
+                    )
+                    .putLong(KEY_COURSE_PALETTE_FOREGROUND, foreground)
+                val darkColors = args["darkColors"] as? List<*>
+                val darkForeground =
+                    (args["darkForegroundColor"] as? Number)?.toLong()
+                if (darkColors != null && darkForeground != null) {
+                    editor
+                        .putString(
+                            KEY_COURSE_PALETTE_DARK_COLORS,
+                            darkColors.joinToString(",") {
+                                ((it as? Number)?.toLong() ?: 0L).toString()
+                            },
+                        )
+                        .putLong(
+                            KEY_COURSE_PALETTE_DARK_FOREGROUND,
+                            darkForeground,
+                        )
+                } else {
+                    editor
+                        .remove(KEY_COURSE_PALETTE_DARK_COLORS)
+                        .remove(KEY_COURSE_PALETTE_DARK_FOREGROUND)
+                }
+                editor.apply()
+                notifyWidgetUpdate()
                 result.success(null)
             }
             else -> result.notImplemented()

--- a/packages/ap_common_plugin/android/src/main/kotlin/me/rainvisitor/ap_common_plugin/CoursePalette.kt
+++ b/packages/ap_common_plugin/android/src/main/kotlin/me/rainvisitor/ap_common_plugin/CoursePalette.kt
@@ -1,0 +1,89 @@
+package me.rainvisitor.ap_common_plugin
+
+import android.content.Context
+import android.content.res.Configuration
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Reads the palette the Flutter side pushed via
+ * `ApCommonPlugin.setCoursePalette`, falling back to the legacy
+ * hardcoded Material 400 palette when nothing has been set yet.
+ */
+object CoursePalette {
+    /** Legacy hardcoded palette — identical to the old hardcoded
+     *  `courseColorPalette` that lived inside each widget. Used when
+     *  the Flutter app hasn't pushed a palette yet (fresh install). */
+    private val legacyColors = listOf(
+        Color(0xFF5C6BC0),
+        Color(0xFF26A69A),
+        Color(0xFFEF5350),
+        Color(0xFFAB47BC),
+        Color(0xFF42A5F5),
+        Color(0xFFFF7043),
+        Color(0xFF66BB6A),
+        Color(0xFFFFCA28),
+        Color(0xFF8D6E63),
+        Color(0xFF78909C),
+        Color(0xFFEC407A),
+        Color(0xFF7E57C2),
+    )
+
+    data class Resolved(
+        val colors: List<Color>,
+        val foreground: Color,
+    )
+
+    fun resolve(context: Context): Resolved {
+        val prefs = context.getSharedPreferences(
+            ApCommonPlugin.PREF_NAME,
+            Context.MODE_PRIVATE,
+        )
+        val isDark =
+            (context.resources.configuration.uiMode and
+                Configuration.UI_MODE_NIGHT_MASK) ==
+                Configuration.UI_MODE_NIGHT_YES
+
+        val colorsKey =
+            if (isDark)
+                ApCommonPlugin.KEY_COURSE_PALETTE_DARK_COLORS
+            else
+                ApCommonPlugin.KEY_COURSE_PALETTE_COLORS
+        val foregroundKey =
+            if (isDark)
+                ApCommonPlugin.KEY_COURSE_PALETTE_DARK_FOREGROUND
+            else
+                ApCommonPlugin.KEY_COURSE_PALETTE_FOREGROUND
+
+        // Fall back to the light variant if dark hasn't been pushed.
+        val rawColors = prefs.getString(colorsKey, null)
+            ?: prefs.getString(
+                ApCommonPlugin.KEY_COURSE_PALETTE_COLORS,
+                null,
+            )
+        val rawForeground = prefs.getLong(foregroundKey, Long.MIN_VALUE)
+            .takeIf { it != Long.MIN_VALUE }
+            ?: prefs.getLong(
+                ApCommonPlugin.KEY_COURSE_PALETTE_FOREGROUND,
+                Long.MIN_VALUE,
+            )
+
+        val colors = rawColors
+            ?.split(",")
+            ?.mapNotNull { it.trim().toLongOrNull()?.let(::argbToColor) }
+            ?.takeIf { it.isNotEmpty() }
+            ?: legacyColors
+        val foreground =
+            if (rawForeground != Long.MIN_VALUE) argbToColor(rawForeground)
+            else Color.White
+
+        return Resolved(colors = colors, foreground = foreground)
+    }
+
+    private fun argbToColor(argb: Long): Color {
+        val alpha = ((argb shr 24) and 0xFF).toInt()
+        val red = ((argb shr 16) and 0xFF).toInt()
+        val green = ((argb shr 8) and 0xFF).toInt()
+        val blue = (argb and 0xFF).toInt()
+        return Color(red = red, green = green, blue = blue, alpha = alpha)
+    }
+}

--- a/packages/ap_common_plugin/android/src/main/kotlin/me/rainvisitor/ap_common_plugin/CourseTableWidget.kt
+++ b/packages/ap_common_plugin/android/src/main/kotlin/me/rainvisitor/ap_common_plugin/CourseTableWidget.kt
@@ -48,22 +48,6 @@ class CourseTableWidget : GlanceAppWidget() {
     companion object {
         private val json = Json { ignoreUnknownKeys = true }
 
-        // Course palette matching Flutter's courseColors
-        private val courseColorPalette = listOf(
-            Color(0xFF5C6BC0), // Indigo
-            Color(0xFF26A69A), // Teal
-            Color(0xFFEF5350), // Red
-            Color(0xFFAB47BC), // Purple
-            Color(0xFF42A5F5), // Blue
-            Color(0xFFFF7043), // Deep Orange
-            Color(0xFF66BB6A), // Green
-            Color(0xFFFFCA28), // Amber
-            Color(0xFF8D6E63), // Brown
-            Color(0xFF78909C), // Blue Grey
-            Color(0xFFEC407A), // Pink
-            Color(0xFF7E57C2), // Deep Purple
-        )
-
         private val headerBackground = androidx.glance.color.ColorProvider(
             day = Color(0xFF2673FF),
             night = Color(0xFF1A1C2E),
@@ -170,6 +154,7 @@ class CourseTableWidget : GlanceAppWidget() {
 
     @Composable
     private fun CourseGrid(context: Context, data: CourseData) {
+        val palette = CoursePalette.resolve(context).colors
         val hasHoliday = data.courses.any { course ->
             course.times.any { it.weekday >= 6 }
         }
@@ -212,7 +197,7 @@ class CourseTableWidget : GlanceAppWidget() {
                 val course = dayMap[t] ?: continue
                 if (course.code !in colorMap) {
                     colorMap[course.code] =
-                        courseColorPalette[colorIdx % courseColorPalette.size]
+                        palette[colorIdx % palette.size]
                     colorIdx++
                 }
             }
@@ -324,7 +309,7 @@ class CourseTableWidget : GlanceAppWidget() {
                     for (d in 1..weekdayCount) {
                         val course = lookup[d]?.get(t)
                         val color = colorMap[course?.code]
-                            ?: courseColorPalette[0]
+                            ?: palette[0]
                         val daySpans = spanStart[d]
                         val span = daySpans?.get(t) // non-null = first slot
                         // Determine position within a merged span

--- a/packages/ap_common_plugin/android/src/main/kotlin/me/rainvisitor/ap_common_plugin/TodayScheduleWidget.kt
+++ b/packages/ap_common_plugin/android/src/main/kotlin/me/rainvisitor/ap_common_plugin/TodayScheduleWidget.kt
@@ -44,13 +44,6 @@ class TodayScheduleWidget : GlanceAppWidget() {
     companion object {
         private val json = Json { ignoreUnknownKeys = true }
 
-        private val courseColorPalette = listOf(
-            Color(0xFF5C6BC0), Color(0xFF26A69A), Color(0xFFEF5350),
-            Color(0xFFAB47BC), Color(0xFF42A5F5), Color(0xFFFF7043),
-            Color(0xFF66BB6A), Color(0xFFFFCA28), Color(0xFF8D6E63),
-            Color(0xFF78909C), Color(0xFFEC407A), Color(0xFF7E57C2),
-        )
-
         private val headerBg = androidx.glance.color.ColorProvider(
             day = Color(0xFF2673FF),
             night = Color(0xFF1A1C2E),
@@ -85,6 +78,7 @@ class TodayScheduleWidget : GlanceAppWidget() {
         context: Context,
         courses: List<ScheduleItem>,
     ) {
+        val palette = CoursePalette.resolve(context).colors
         val launchIntent = context.packageManager
             .getLaunchIntentForPackage(context.packageName)
 
@@ -144,7 +138,7 @@ class TodayScheduleWidget : GlanceAppWidget() {
                         .padding(horizontal = 12.dp, vertical = 8.dp),
                 ) {
                     for ((index, item) in courses.withIndex()) {
-                        ScheduleRow(item, index)
+                        ScheduleRow(item, index, palette)
                         if (index < courses.size - 1) {
                             Spacer(modifier = GlanceModifier.height(6.dp))
                         }
@@ -155,11 +149,14 @@ class TodayScheduleWidget : GlanceAppWidget() {
     }
 
     @Composable
-    private fun ScheduleRow(item: ScheduleItem, index: Int) {
-        val color = courseColorPalette[
+    private fun ScheduleRow(
+        item: ScheduleItem,
+        index: Int,
+        palette: List<Color>,
+    ) {
+        val color = palette[
             item.course.code.hashCode().let {
-                ((it % courseColorPalette.size) + courseColorPalette.size) %
-                    courseColorPalette.size
+                ((it % palette.size) + palette.size) % palette.size
             }
         ]
 

--- a/packages/ap_common_plugin/ios/Classes/SwiftApCommonPlugin.swift
+++ b/packages/ap_common_plugin/ios/Classes/SwiftApCommonPlugin.swift
@@ -6,6 +6,14 @@ public class SwiftApCommonPlugin: NSObject, FlutterPlugin {
     private static let keyAppGroupId = "app_group_id"
     private static let keyCourseNotify = "course_notify"
     private static let keyUserInfo = "user_info"
+    private static let keyCoursePaletteId = "course_palette_id"
+    private static let keyCoursePaletteColors = "course_palette_colors"
+    private static let keyCoursePaletteForeground =
+        "course_palette_foreground"
+    private static let keyCoursePaletteDarkColors =
+        "course_palette_dark_colors"
+    private static let keyCoursePaletteDarkForeground =
+        "course_palette_dark_foreground"
     private static let prefName = "ap_common_plugin"
 
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -99,6 +107,67 @@ public class SwiftApCommonPlugin: NSObject, FlutterPlugin {
             if let appGroupId = appGroupId,
                let groupDefaults = UserDefaults(suiteName: appGroupId) {
                 groupDefaults.removeObject(forKey: SwiftApCommonPlugin.keyUserInfo)
+            }
+            if #available(iOS 14.0, *) {
+                WidgetCenter.shared.reloadAllTimelines()
+            }
+            result(nil)
+        case "setCoursePalette":
+            guard let args = call.arguments as? [String: Any],
+                  let id = args["id"] as? String,
+                  let colors = args["colors"] as? [Int64],
+                  let foreground = args["foregroundColor"] as? Int64 else {
+                result(
+                    FlutterError(
+                        code: "INVALID_ARGUMENT",
+                        message: "id, colors, foregroundColor are required",
+                        details: nil
+                    )
+                )
+                return
+            }
+            let appGroupId = UserDefaults.standard.string(
+                forKey: SwiftApCommonPlugin.keyAppGroupId
+            )
+            if let appGroupId = appGroupId,
+               let groupDefaults = UserDefaults(suiteName: appGroupId) {
+                groupDefaults.set(
+                    id,
+                    forKey: SwiftApCommonPlugin.keyCoursePaletteId
+                )
+                groupDefaults.set(
+                    colors,
+                    forKey: SwiftApCommonPlugin.keyCoursePaletteColors
+                )
+                groupDefaults.set(
+                    foreground,
+                    forKey: SwiftApCommonPlugin.keyCoursePaletteForeground
+                )
+                if let darkColors = args["darkColors"] as? [Int64],
+                   let darkForeground =
+                    args["darkForegroundColor"] as? Int64 {
+                    groupDefaults.set(
+                        darkColors,
+                        forKey:
+                            SwiftApCommonPlugin.keyCoursePaletteDarkColors
+                    )
+                    groupDefaults.set(
+                        darkForeground,
+                        forKey:
+                            SwiftApCommonPlugin
+                            .keyCoursePaletteDarkForeground
+                    )
+                } else {
+                    groupDefaults.removeObject(
+                        forKey:
+                            SwiftApCommonPlugin.keyCoursePaletteDarkColors
+                    )
+                    groupDefaults.removeObject(
+                        forKey:
+                            SwiftApCommonPlugin
+                            .keyCoursePaletteDarkForeground
+                    )
+                }
             }
             if #available(iOS 14.0, *) {
                 WidgetCenter.shared.reloadAllTimelines()

--- a/packages/ap_common_plugin/ios/CourseAppWidget/CoursePalette.swift
+++ b/packages/ap_common_plugin/ios/CourseAppWidget/CoursePalette.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+import WidgetKit
+
+/// Reads the palette the Flutter side pushed via
+/// `ApCommonPlugin.setCoursePalette`, falling back to the legacy
+/// hardcoded Material 400 palette when no palette has been set yet.
+enum CoursePalette {
+    private static let keyId = "course_palette_id"
+    private static let keyColors = "course_palette_colors"
+    private static let keyForeground = "course_palette_foreground"
+    private static let keyDarkColors = "course_palette_dark_colors"
+    private static let keyDarkForeground = "course_palette_dark_foreground"
+
+    /// Legacy Material 400 palette — matches the previous hardcoded
+    /// list so existing installs keep the same visual until the user
+    /// opens the app and pushes a new palette.
+    private static let legacyColors: [Color] = [
+        Color(red: 0.36, green: 0.42, blue: 0.75), // Indigo
+        Color(red: 0.15, green: 0.65, blue: 0.60), // Teal
+        Color(red: 0.94, green: 0.33, blue: 0.31), // Red
+        Color(red: 0.67, green: 0.28, blue: 0.74), // Purple
+        Color(red: 0.26, green: 0.65, blue: 0.96), // Blue
+        Color(red: 1.00, green: 0.44, blue: 0.26), // Deep Orange
+        Color(red: 0.40, green: 0.73, blue: 0.42), // Green
+        Color(red: 1.00, green: 0.79, blue: 0.16), // Amber
+        Color(red: 0.55, green: 0.43, blue: 0.39), // Brown
+        Color(red: 0.47, green: 0.56, blue: 0.61), // Blue Grey
+        Color(red: 0.93, green: 0.25, blue: 0.48), // Pink
+        Color(red: 0.49, green: 0.34, blue: 0.76), // Deep Purple
+    ]
+
+    struct Resolved {
+        let colors: [Color]
+        let foreground: Color
+    }
+
+    /// Resolves the palette for the given [colorScheme], picking dark
+    /// variants when available.
+    static func resolve(for colorScheme: ColorScheme) -> Resolved {
+        guard let groupDefaults = UserDefaults(suiteName: appGroupId) else {
+            return Resolved(colors: legacyColors, foreground: .white)
+        }
+        let isDark = colorScheme == .dark
+
+        let colorsKey = isDark ? keyDarkColors : keyColors
+        let foregroundKey = isDark ? keyDarkForeground : keyForeground
+
+        let rawColors = groupDefaults.array(forKey: colorsKey)
+            ?? groupDefaults.array(forKey: keyColors)
+        let rawForeground = groupDefaults.object(forKey: foregroundKey)
+            ?? groupDefaults.object(forKey: keyForeground)
+
+        let colors: [Color]
+        if let raw = rawColors as? [Int64], !raw.isEmpty {
+            colors = raw.map { argbToColor($0) }
+        } else if let raw = rawColors as? [Int], !raw.isEmpty {
+            colors = raw.map { argbToColor(Int64($0)) }
+        } else if let raw = rawColors as? [NSNumber], !raw.isEmpty {
+            colors = raw.map { argbToColor($0.int64Value) }
+        } else {
+            colors = legacyColors
+        }
+
+        let foreground: Color
+        if let number = rawForeground as? NSNumber {
+            foreground = argbToColor(number.int64Value)
+        } else {
+            foreground = .white
+        }
+
+        return Resolved(colors: colors, foreground: foreground)
+    }
+
+    private static func argbToColor(_ argb: Int64) -> Color {
+        let alpha = Double((argb >> 24) & 0xFF) / 255.0
+        let red = Double((argb >> 16) & 0xFF) / 255.0
+        let green = Double((argb >> 8) & 0xFF) / 255.0
+        let blue = Double(argb & 0xFF) / 255.0
+        return Color(.sRGB, red: red, green: green, blue: blue, opacity: alpha)
+    }
+}

--- a/packages/ap_common_plugin/ios/CourseAppWidget/CourseTableWidget.swift
+++ b/packages/ap_common_plugin/ios/CourseAppWidget/CourseTableWidget.swift
@@ -54,23 +54,6 @@ struct CourseTableEntry: TimelineEntry {
     let courseData: CourseData?
 }
 
-// MARK: - Color Palette (matching Flutter)
-
-private let courseColorPalette: [Color] = [
-    Color(red: 0.36, green: 0.42, blue: 0.75), // Indigo
-    Color(red: 0.15, green: 0.65, blue: 0.60), // Teal
-    Color(red: 0.94, green: 0.33, blue: 0.31), // Red
-    Color(red: 0.67, green: 0.28, blue: 0.74), // Purple
-    Color(red: 0.26, green: 0.65, blue: 0.96), // Blue
-    Color(red: 1.00, green: 0.44, blue: 0.26), // Deep Orange
-    Color(red: 0.40, green: 0.73, blue: 0.42), // Green
-    Color(red: 1.00, green: 0.79, blue: 0.16), // Amber
-    Color(red: 0.55, green: 0.43, blue: 0.39), // Brown
-    Color(red: 0.47, green: 0.56, blue: 0.61), // Blue Grey
-    Color(red: 0.93, green: 0.25, blue: 0.48), // Pink
-    Color(red: 0.49, green: 0.34, blue: 0.76), // Deep Purple
-]
-
 // MARK: - Course Table View
 
 struct CourseTableView: View {
@@ -138,11 +121,13 @@ struct CourseTableView: View {
         let weekdayCount = hasHoliday ? 7 : 5
         let (minIdx, maxIdx) = timeRange(data)
         let lookup = buildLookup(data)
+        let palette = CoursePalette.resolve(for: colorScheme).colors
         let colorMap = buildColorMap(
             lookup: lookup,
             weekdayCount: weekdayCount,
             minIdx: minIdx,
-            maxIdx: maxIdx
+            maxIdx: maxIdx,
+            palette: palette
         )
         let todayWeekday = currentWeekday()
         let isCompact = family == .systemSmall
@@ -234,13 +219,13 @@ struct CourseTableView: View {
                                 continuationColor: isContinuation
                                     ? colorMap[
                                         course!.code,
-                                        default: courseColorPalette[0]
+                                        default: palette[0]
                                     ]
                                     : nil,
                                 color: course != nil
                                     ? colorMap[
                                         course!.code,
-                                        default: courseColorPalette[0]
+                                        default: palette[0]
                                     ]
                                     : .clear,
                                 width: cellWidth,
@@ -381,7 +366,8 @@ struct CourseTableView: View {
         lookup: [Int: [Int: Course]],
         weekdayCount: Int,
         minIdx: Int,
-        maxIdx: Int
+        maxIdx: Int,
+        palette: [Color]
     ) -> [String: Color] {
         var map: [String: Color] = [:]
         var idx = 0
@@ -390,9 +376,7 @@ struct CourseTableView: View {
             for t in minIdx...maxIdx {
                 guard let course = dayMap[t] else { continue }
                 if map[course.code] == nil {
-                    map[course.code] = courseColorPalette[
-                        idx % courseColorPalette.count
-                    ]
+                    map[course.code] = palette[idx % palette.count]
                     idx += 1
                 }
             }

--- a/packages/ap_common_plugin/ios/CourseAppWidget/TodayScheduleWidget.swift
+++ b/packages/ap_common_plugin/ios/CourseAppWidget/TodayScheduleWidget.swift
@@ -106,20 +106,11 @@ struct TodayScheduleProvider: TimelineProvider {
     }
 
     private func courseColor(_ code: String) -> Color {
-        let colors: [Color] = [
-            Color(red: 0.36, green: 0.42, blue: 0.75),
-            Color(red: 0.15, green: 0.65, blue: 0.60),
-            Color(red: 0.94, green: 0.33, blue: 0.31),
-            Color(red: 0.67, green: 0.28, blue: 0.74),
-            Color(red: 0.26, green: 0.65, blue: 0.96),
-            Color(red: 1.00, green: 0.44, blue: 0.26),
-            Color(red: 0.40, green: 0.73, blue: 0.42),
-            Color(red: 1.00, green: 0.79, blue: 0.16),
-            Color(red: 0.55, green: 0.43, blue: 0.39),
-            Color(red: 0.47, green: 0.56, blue: 0.61),
-            Color(red: 0.93, green: 0.25, blue: 0.48),
-            Color(red: 0.49, green: 0.34, blue: 0.76),
-        ]
+        // Timeline providers don't have an Environment, so resolve for
+        // the light palette here. Dark-mode swap for this widget can
+        // follow in a later pass if the view switches to inline color
+        // resolution.
+        let colors = CoursePalette.resolve(for: .light).colors
         let idx = abs(code.hashValue) % colors.count
         return colors[idx]
     }

--- a/packages/ap_common_plugin/lib/ap_common_plugin.dart
+++ b/packages/ap_common_plugin/lib/ap_common_plugin.dart
@@ -87,6 +87,33 @@ class ApCommonPlugin {
     await _invoke<void>('clearUserInfoWidget');
   }
 
+  /// Push the active course palette to native widgets so the Android
+  /// AppWidget / iOS WidgetKit extension can render course cards with
+  /// the same colors the user picked in-app.
+  ///
+  /// [id] is the palette identifier (e.g. `material400`, `appleSystem`).
+  /// [colors] and [foregroundColor] are ARGB ints (same encoding as
+  /// `Color.toARGB32()` on Flutter side).
+  /// When the palette carries a dark variant, pass [darkColors] and
+  /// [darkForegroundColor] so the native widget can switch with the
+  /// system appearance. Otherwise leave them null.
+  static Future<void> setCoursePalette({
+    required String id,
+    required List<int> colors,
+    required int foregroundColor,
+    List<int>? darkColors,
+    int? darkForegroundColor,
+  }) async {
+    await _invoke<void>('setCoursePalette', <String, Object?>{
+      'id': id,
+      'colors': colors,
+      'foregroundColor': foregroundColor,
+      if (darkColors != null) 'darkColors': darkColors,
+      if (darkForegroundColor != null)
+        'darkForegroundColor': darkForegroundColor,
+    });
+  }
+
   /// Update the course widget with fake data for testing.
   ///
   /// Injects two courses starting 30 and 90 minutes from now

--- a/packages/ap_common_plugin/lib/ap_common_plugin.dart
+++ b/packages/ap_common_plugin/lib/ap_common_plugin.dart
@@ -1,25 +1,53 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:developer';
 
 import 'package:ap_common_core/ap_common_core.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 class ApCommonPlugin {
   static const MethodChannel _channel = MethodChannel('ap_common_plugin');
 
+  /// Platforms that ship a native implementation of this plugin.
+  /// On any other platform (web, desktop, tests) channel calls are
+  /// silently skipped so callers don't have to guard every invocation.
+  static bool get _isSupported =>
+      !kIsWeb &&
+      (defaultTargetPlatform == TargetPlatform.android ||
+          defaultTargetPlatform == TargetPlatform.iOS);
+
+  /// Invoke [method] on the plugin channel, swallowing the
+  /// [MissingPluginException] that gets thrown on platforms without a
+  /// native implementation (e.g. Flutter Web).
+  static Future<T?> _invoke<T>(
+    String method, [
+    Object? arguments,
+  ]) async {
+    if (!_isSupported) return null;
+    try {
+      return await _channel.invokeMethod<T>(method, arguments);
+    } on MissingPluginException catch (e) {
+      log(
+        'ap_common_plugin: "$method" not available on this platform — '
+        'skipping. ${e.message}',
+        name: 'ap_common_plugin',
+      );
+      return null;
+    }
+  }
+
   static Future<String?> get platformVersion async {
-    final String? version =
-        await _channel.invokeMethod<String>('getPlatformVersion');
-    return version;
+    return _invoke<String>('getPlatformVersion');
   }
 
   /// Configure the plugin with platform-specific settings.
   ///
   /// [appGroupId] is required on iOS for sharing data with the
   /// WidgetKit extension via App Group UserDefaults.
-  /// It is ignored on Android.
+  /// It is ignored on Android, and the call is a no-op on web/desktop.
   static Future<void> configure({required String appGroupId}) async {
-    await _channel.invokeMethod<void>('configure', <String, String>{
+    await _invoke<void>('configure', <String, String>{
       'appGroupId': appGroupId,
     });
   }
@@ -30,8 +58,9 @@ class ApCommonPlugin {
   /// refresh.
   /// On iOS, writes to App Group UserDefaults so the WidgetKit
   /// extension can read it.
+  /// On web/desktop this is a no-op.
   static Future<void> updateCourseWidget(CourseData courseData) async {
-    await _channel.invokeMethod<void>(
+    await _invoke<void>(
       'updateCourseWidget',
       jsonEncode(courseData.toJson()),
     );
@@ -39,7 +68,7 @@ class ApCommonPlugin {
 
   /// Clear the course widget data.
   static Future<void> clearCourseWidget() async {
-    await _channel.invokeMethod<void>('clearCourseWidget');
+    await _invoke<void>('clearCourseWidget');
   }
 
   /// Update the student ID widget with user info.
@@ -47,7 +76,7 @@ class ApCommonPlugin {
   /// Sends a JSON object with `id`, `name`, `department`, and
   /// `className` fields to the native widget.
   static Future<void> updateUserInfoWidget(UserInfo userInfo) async {
-    await _channel.invokeMethod<void>(
+    await _invoke<void>(
       'updateUserInfoWidget',
       jsonEncode(userInfo.toJson()),
     );
@@ -55,7 +84,7 @@ class ApCommonPlugin {
 
   /// Clear the student ID widget data.
   static Future<void> clearUserInfoWidget() async {
-    await _channel.invokeMethod<void>('clearUserInfoWidget');
+    await _invoke<void>('clearUserInfoWidget');
   }
 
   /// Update the course widget with fake data for testing.


### PR DESCRIPTION
## 摘要

關閉 #185。

這個 PR 為 `CourseScaffold` 引入完整的課表配色系統，讓使用者能在 App 內自由切換配色，並自動同步到 Android / iOS 桌面小工具。

## 主要變更

### 1. CoursePaletteTheme（ThemeExtension）
- 新增 `CoursePaletteTheme` — 固定 12 色的調色盤型別，透過 `ThemeData.extensions` 注入
- 內建 **6 組** palette：
  - `material` — Material 400（預設，視覺與舊版 `courseColors` 完全一致）
  - `materialBold` — Material 600，更鮮明
  - `appleSystem` — iOS System Colors（**自帶 dark 變體**，iOS 13–26 穩定值）
  - `nord` — Nord 冷調設計師最愛（黑字前景）
  - `vibrant` — Material Accent A400/A700 高飽和
  - `pastel` — Google Calendar 風粉彩
- 可選 `dark` 欄位：palette 可自帶 dark 變體，`of()` / `resolvedFor()` 自動依 `Brightness` 切換
- 注入三種方式任選：
  - `MaterialApp(theme: ThemeData(...).copyWith(extensions: [CoursePaletteTheme.appleSystem]))`
  - `ApTheme.light(seed, coursePalette: ...)` / `ApTheme.dark(...)`
  - `ApApp(coursePalette: ...)`

### 2. CourseScaffold 內建配色切換器
- AppBar 多一顆 palette 圖示 → 開底部選單（`CoursePalettePickerSheet`）
- 每組 palette 顯示 12 色預覽；有 dark 變體的多顯示一列 dark 色點與 `Auto dark` 徽章
- 選擇後：
  - 立刻透過 local `Theme` override 套用到當前 scaffold（含 `CourseContent` / `CourseEditSheet` 等 modal）
  - 寫入 `PreferenceUtil`（key: `CoursePaletteTheme.preferenceKey`）
  - 自動推送到原生端（下述）
- 可透過 `enablePaletteSelector: false` 關閉此功能

### 3. 文字顏色固定、不再依課表色亮度切換
- 舊版用 `ThemeData.estimateBrightnessForColor` 依每張卡片背景決定 white/black，造成同一畫面中有些卡片白字、有些黑字
- 改為 `palette.foregroundColor` — 同 palette 下所有卡片文字顏色一致

### 4. 原生桌面小工具同步（Android + iOS）
- 新增 `ApCommonPlugin.setCoursePalette()` Dart API，推送 12 色 ARGB + foreground（含 dark 變體）到原生
- **Android**：新 `CoursePalette.kt` helper，依 `Configuration.UI_MODE_NIGHT_MASK` 切換 light/dark，fallback 到舊版硬編碼。`CourseTableWidget` / `TodayScheduleWidget` 改走 helper
- **iOS**：新 `CoursePalette.swift` helper，依 SwiftUI `colorScheme` 切換。`CourseTableWidget.swift` render 時動態解析；`TodayScheduleWidget.swift` 在 Timeline Provider 解析（目前僅 light，dark 留待後續）
- `CourseScaffold` 透過 MethodChannel 直接呼叫（**不需加 plugin 依賴**），MissingPluginException 靜默處理

### 5. ApTheme 新增 iOSThemeColors
- 在 App seed 色層級也提供 iOS 風選擇：新增 `ApTheme.iOSThemeColors`（10 組 iOS System Colors 對應 NKUST 既有 10 組品牌色）
- 可 drop-in 替換使用

### 6. 其他修正
- `ApCommonPlugin` 在 web / 不支援平台加防護（`MissingPluginException` 統一吞掉 + log）
- `CourseEditSheet.show` 把外層 `CoursePaletteTheme` 重新注入到 modal builder，自訂課程色塊選擇器隨 scaffold palette 切換
- `CourseList` 的 modal 同樣處理

## 相容性保證

- **不升級就不會變**：未注入 palette 時視覺與現狀完全相同（預設為 `material`）
- **12 色長度不變**：舊 `Course.colorIndex` 資料不會錯位
- `courseColors` 常數保留 export 作為 fallback / 向下相容
- 原生小工具在 Flutter 端沒推 palette 時 fallback 到舊版硬編碼值

## 主要檔案變更

| 檔案 | 說明 |
|---|---|
| `theme/course_palette_theme.dart` | 新增 — `CoursePaletteTheme` + 6 組內建 palette + dark 變體支援 |
| `widgets/course_palette_picker_sheet.dart` | 新增 — 底部選色 sheet（含 light/dark 預覽） |
| `scaffold/course_scaffold.dart` | palette 狀態管理 / AppBar 圖示 / Theme override / 原生同步 |
| `widgets/course_edit_sheet.dart` | 色塊選擇器使用 palette；`show()` 透過 Theme 重新注入到 modal |
| `widgets/home_dashboard_widgets.dart` | 首頁今日課表色彩走 palette |
| `resources/ap_theme.dart` | `ApTheme.light/dark` 接受 `coursePalette`；新增 `iOSThemeColors` |
| `pages/ap_app.dart` | `ApApp` 多 `coursePalette` 參數 |
| `ap_common_plugin/lib/ap_common_plugin.dart` | 新增 `setCoursePalette` API；所有方法加 web/platform 防護 |
| `ap_common_plugin/android/.../ApCommonPlugin.kt` | 新增 `setCoursePalette` handler，寫 5 個 SharedPreferences key |
| `ap_common_plugin/android/.../CoursePalette.kt` | 新增 — Android palette 讀取 helper |
| `ap_common_plugin/android/.../CourseTableWidget.kt` / `TodayScheduleWidget.kt` | 移除硬編碼，改走 helper |
| `ap_common_plugin/ios/Classes/SwiftApCommonPlugin.swift` | 新增 `setCoursePalette` handler |
| `ap_common_plugin/ios/CourseAppWidget/CoursePalette.swift` | 新增 — iOS palette 讀取 helper |
| `ap_common_plugin/ios/CourseAppWidget/CourseTableWidget.swift` / `TodayScheduleWidget.swift` | 移除硬編碼，改走 helper |

## 測試計畫

- [x] `melos run test` 全通過（CI 驗證）
- [x] `melos run analyze-ci` 全通過（CI 驗證）
- [x] iOS Build Test pass
- [x] Android APK / Web build pass
- [x] 手動驗證：在 Android 實機切 palette，桌面 widget 同步
- [x] 手動驗證：iOS 實機切 palette，WidgetKit 同步（需先 `configure(appGroupId: ...)`）
- [x] 手動驗證：切 dark mode 時 `appleSystem` 自動切到 dark 變體
- [x] 手動驗證：自訂課程的色塊選擇器色組與當前 palette 一致

## 後續 follow-up（不在本 PR）

- `iOS TodayScheduleWidget` dark mode 切換（Timeline Provider 沒 Environment，需要 view 層做）
- `Material Bold` / `Nord` / `Vibrant` / `Pastel` 的 dark 變體
- `announcement_ui/tag_colors.dart` 10 色改為獨立 `TagPaletteTheme`
- Settings 頁面整合 palette picker，讓使用者無需進入 CourseScaffold 也能切換

## Mermaid 流程圖

\`\`\`mermaid
flowchart TB
    subgraph Flutter 層
      A[CoursePaletteTheme] --> B{ApApp / ApTheme extensions}
      B --> C[CourseScaffold]
      C --> D[AppBar 圖示]
      D --> E[CoursePalettePickerSheet]
      E -->|save| F[PreferenceUtil]
      E -->|sync| G[MethodChannel<br/>ap_common_plugin]
      C --> H[CourseContent / CourseEditSheet]
    end
    subgraph 原生層
      G --> I[Android<br/>SharedPreferences]
      G --> J[iOS App Group<br/>UserDefaults]
      I --> K[CourseTableWidget / TodayScheduleWidget]
      J --> L[CourseTableWidget.swift / TodayScheduleWidget.swift]
    end
\`\`\`