### PR TITLE
feat: Add showPRCard option and improve ScoreGPACard layout handling

### DIFF
--- a/packages/ap_common_flutter_ui/lib/src/scaffold/score_scaffold.dart
+++ b/packages/ap_common_flutter_ui/lib/src/scaffold/score_scaffold.dart
@@ -25,9 +25,11 @@ class ScoreScaffold extends StatefulWidget {
     this.finalScoreBuilder,
     this.customHint,
     this.isShowSearchButton = false,
+    this.showPRCard,
     this.bottom,
     this.customStateHint,
     this.semesterPickerController,
+    this.semesterPickerUiConfig,
   });
 
   /// Creates a [ScoreScaffold] from a [DataState<ScoreData>].
@@ -53,8 +55,10 @@ class ScoreScaffold extends StatefulWidget {
     this.middleScoreBuilder,
     this.finalScoreBuilder,
     this.isShowSearchButton = false,
+    this.showPRCard = true,
     this.bottom,
     this.semesterPickerController,
+    this.semesterPickerUiConfig,
   })  : state = dataState.when(
           loading: () => ScoreState.loading,
           loaded: (_, __) => ScoreState.finish,
@@ -87,6 +91,7 @@ class ScoreScaffold extends StatefulWidget {
   final Widget Function(int index)? finalScoreBuilder;
 
   final bool isShowSearchButton;
+  final bool? showPRCard;
 
   final String? customHint;
 
@@ -94,6 +99,9 @@ class ScoreScaffold extends StatefulWidget {
 
   /// Optional controller for the semester picker.
   final SemesterPickerController? semesterPickerController;
+
+  /// Optional UI config for the semester picker.
+  final SemesterUIConfig? semesterPickerUiConfig;
 
   @override
   ScoreScaffoldState createState() => ScoreScaffoldState();
@@ -139,36 +147,33 @@ class ScoreScaffoldState extends State<ScoreScaffold> {
     return Scaffold(
       backgroundColor: colorScheme.surface,
       appBar: AppBar(
+        centerTitle: false,
         titleSpacing: 0,
-        title: Row(
-          children: <Widget>[
-            Flexible(
-              child: Text(
-                widget.title ?? context.ap.score,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-            if (widget.itemPicker != null) ...<Widget>[
-              const SizedBox(width: 12),
-              widget.itemPicker!,
-            ],
-            if (widget.semesterData != null &&
-                widget.itemPicker == null) ...<Widget>[
-              const SizedBox(width: 12),
-              SemesterPicker(
-                semesterData: widget.semesterData!,
-                currentIndex: widget.semesterData!.currentIndex,
-                onSelect: (Semester semester, int index) {
-                  widget.onSelect?.call(index);
-                },
-                featureTag: 'score',
-                controller: widget.semesterPickerController,
-              ),
-            ],
-          ],
+        title: Text(
+          widget.title ?? context.ap.score,
+          overflow: TextOverflow.ellipsis,
         ),
         bottom: widget.bottom as PreferredSizeWidget?,
-        actions: const <Widget>[],
+        actions: <Widget>[
+          if (widget.itemPicker != null) ...<Widget>[
+            widget.itemPicker!,
+            const SizedBox(width: 12),
+          ],
+          if (widget.semesterData != null &&
+              widget.itemPicker == null) ...<Widget>[
+            SemesterPicker(
+              semesterData: widget.semesterData!,
+              currentIndex: widget.semesterData!.currentIndex,
+              onSelect: (Semester semester, int index) {
+                widget.onSelect?.call(index);
+              },
+              featureTag: 'score',
+              controller: widget.semesterPickerController,
+              uiConfig: widget.semesterPickerUiConfig,
+            ),
+            const SizedBox(width: 12),
+          ],
+        ],
       ),
       floatingActionButton: AnimatedScale(
         scale: _showFab ? 1.0 : 0.0,
@@ -332,6 +337,7 @@ class ScoreScaffoldState extends State<ScoreScaffold> {
           finalScoreBuilder: widget.finalScoreBuilder,
           isAnalysisView: isLandscape || _isAnalysisView,
           scrollController: _scrollController,
+          showPRCard: widget.showPRCard,
         );
     }
   }
@@ -435,6 +441,7 @@ class ScoreContent extends StatefulWidget {
     this.finalScoreBuilder,
     required this.isAnalysisView,
     this.scrollController,
+    this.showPRCard,
   });
 
   final ScoreData? scoreData;
@@ -446,6 +453,7 @@ class ScoreContent extends StatefulWidget {
   final Widget Function(int index)? finalScoreBuilder;
   final bool isAnalysisView;
   final ScrollController? scrollController;
+  final bool? showPRCard;
 
   @override
   _ScoreContentState createState() => _ScoreContentState();
@@ -461,6 +469,7 @@ class _ScoreContentState extends State<ScoreContent> {
         scoreData: widget.scoreData!,
         onRefresh: widget.onRefresh,
         controller: widget.scrollController,
+        showPRCard: widget.showPRCard,
       );
     } else {
       return _ScoreListTab(
@@ -646,8 +655,7 @@ class _ScoreListTab extends StatelessWidget {
     Color scoreColor,
   ) {
     final String raw = _effectiveScoreStr(score) ?? '-';
-    final bool isNumeric =
-        scoreData.scoreType == ScoreType.numeric;
+    final bool isNumeric = scoreData.scoreType == ScoreType.numeric;
 
     if (scoreValue == null) {
       // Cannot parse at all — show raw string
@@ -748,11 +756,13 @@ class _ScoreAnalysisTab extends StatelessWidget {
     required this.scoreData,
     this.onRefresh,
     this.controller,
+    this.showPRCard,
   });
 
   final ScoreData scoreData;
   final VoidCallback? onRefresh;
   final ScrollController? controller;
+  final bool? showPRCard;
 
   @override
   Widget build(BuildContext context) {
@@ -769,8 +779,10 @@ class _ScoreAnalysisTab extends StatelessWidget {
           children: <Widget>[
             _buildMainSummaryCard(colorScheme, context.ap, analysis),
             const SizedBox(height: 16),
-            ScorePRCard(analysis: analysis),
-            const SizedBox(height: 16),
+            if (showPRCard != false) ...<Widget>[
+              ScorePRCard(analysis: analysis),
+              const SizedBox(height: 16),
+            ],
             ScoreGPACard(analysis: analysis),
             const SizedBox(height: 16),
             ScoreStatisticsCard(analysis: analysis),
@@ -956,14 +968,12 @@ class ScoreAnalysis {
   late List<double> _gradePoints;
   late int _totalSubjects;
 
-  bool get isGradePoint =>
-      scoreData.scoreType == ScoreType.gradePoint;
+  bool get isGradePoint => scoreData.scoreType == ScoreType.gradePoint;
 
   /// Whether a numeric score value is considered passing.
   bool isPassing(double scoreValue) {
     if (isGradePoint) {
-      return scoreToGradePoint(scoreValue) >=
-          scoreData.passingGradePoint;
+      return scoreToGradePoint(scoreValue) >= scoreData.passingGradePoint;
     }
     return scoreValue >= scoreData.passingScore;
   }
@@ -1087,9 +1097,7 @@ class ScoreAnalysis {
         _ScoreListTab._effectiveScoreStr(score),
       );
       final double? unit = double.tryParse(score.units);
-      if (scoreValue != null &&
-          isPassing(scoreValue) &&
-          unit != null) {
+      if (scoreValue != null && isPassing(scoreValue) && unit != null) {
         credits += unit;
       }
     }
@@ -1101,12 +1109,10 @@ class ScoreAnalysis {
   /// Returns the effective score string for a [Score], preferring
   /// [Score.semesterScore] and falling back to [Score.finalScore].
   static String? effectiveScoreStr(Score score) {
-    if (score.semesterScore != null &&
-        score.semesterScore!.isNotEmpty) {
+    if (score.semesterScore != null && score.semesterScore!.isNotEmpty) {
       return score.semesterScore;
     }
-    if (score.finalScore != null &&
-        score.finalScore!.isNotEmpty) {
+    if (score.finalScore != null && score.finalScore!.isNotEmpty) {
       return score.finalScore;
     }
     return null;

--- a/packages/ap_common_flutter_ui/lib/src/widgets/score_analysis_widgets.dart
+++ b/packages/ap_common_flutter_ui/lib/src/widgets/score_analysis_widgets.dart
@@ -776,16 +776,29 @@ class ScoreGPACard extends StatelessWidget {
     for (final Score score in analysis.scoreData.scores) {
       final String? raw = ScoreAnalysis.effectiveScoreStr(score);
       final double? value = ScoreAnalysis.parseScore(raw);
-      if (value == null) continue;
-      entries.add(_GradeEntry(
-        title: score.title,
-        score: value,
-        grade: isGradePoint
-            ? (raw ?? '')
-            : ScoreAnalysis.scoreToGradeLetter(value),
-        gradePoint: ScoreAnalysis.scoreToGradePoint(value),
-        credits: double.tryParse(score.units) ?? 0,
-      ),);
+      if (value == null) {
+        entries.add(
+          _GradeEntry(
+            title: score.title,
+            score: 0,
+            grade: '-',
+            gradePoint: ScoreAnalysis.scoreToGradePoint(-1.0),
+            credits: double.tryParse(score.units) ?? 0,
+          ),
+        );
+      } else {
+        entries.add(
+          _GradeEntry(
+            title: score.title,
+            score: value,
+            grade: isGradePoint
+                ? (raw ?? '')
+                : ScoreAnalysis.scoreToGradeLetter(value),
+            gradePoint: ScoreAnalysis.scoreToGradePoint(value),
+            credits: double.tryParse(score.units) ?? 0,
+          ),
+        );
+      }
     }
 
     if (entries.isEmpty) return const SizedBox.shrink();
@@ -825,7 +838,7 @@ class ScoreGPACard extends StatelessWidget {
                 ),
               ),
               SizedBox(
-                width: 40,
+                width: 50,
                 child: Text(
                   context.ap.gradePoint,
                   style: TextStyle(
@@ -871,9 +884,9 @@ class ScoreGPACard extends StatelessWidget {
                     ),
                   ),
                   SizedBox(
-                    width: 40,
+                    width: 50,
                     child: Text(
-                      e.gradePoint.toStringAsFixed(1),
+                      e.gradePoint > 0 ? e.gradePoint.toStringAsFixed(1) : '-',
                       style: TextStyle(
                         fontSize: 13,
                         color: colorScheme.onSurface,

--- a/packages/ap_common_flutter_ui/lib/src/widgets/score_analysis_widgets.dart
+++ b/packages/ap_common_flutter_ui/lib/src/widgets/score_analysis_widgets.dart
@@ -776,29 +776,20 @@ class ScoreGPACard extends StatelessWidget {
     for (final Score score in analysis.scoreData.scores) {
       final String? raw = ScoreAnalysis.effectiveScoreStr(score);
       final double? value = ScoreAnalysis.parseScore(raw);
-      if (value == null) {
-        entries.add(
-          _GradeEntry(
-            title: score.title,
-            score: 0,
-            grade: '-',
-            gradePoint: ScoreAnalysis.scoreToGradePoint(-1.0),
-            credits: double.tryParse(score.units) ?? 0,
-          ),
-        );
-      } else {
-        entries.add(
-          _GradeEntry(
-            title: score.title,
-            score: value,
-            grade: isGradePoint
-                ? (raw ?? '')
-                : ScoreAnalysis.scoreToGradeLetter(value),
-            gradePoint: ScoreAnalysis.scoreToGradePoint(value),
-            credits: double.tryParse(score.units) ?? 0,
-          ),
-        );
-      }
+      final bool isInvalid = value == null;
+      entries.add(
+        _GradeEntry(
+          title: score.title,
+          score: value ?? 0,
+          grade: isInvalid
+              ? '-'
+              : (isGradePoint
+                  ? (raw ?? '')
+                  : ScoreAnalysis.scoreToGradeLetter(value)),
+          gradePoint: isInvalid ? 0.0 : ScoreAnalysis.scoreToGradePoint(value),
+          credits: double.tryParse(score.units) ?? 0,
+        ),
+      );
     }
 
     if (entries.isEmpty) return const SizedBox.shrink();
@@ -886,7 +877,7 @@ class ScoreGPACard extends StatelessWidget {
                   SizedBox(
                     width: 50,
                     child: Text(
-                      e.gradePoint > 0 ? e.gradePoint.toStringAsFixed(1) : '-',
+                      e.grade != '-' ? e.gradePoint.toStringAsFixed(1) : '-',
                       style: TextStyle(
                         fontSize: 13,
                         color: colorScheme.onSurface,


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the `ScoreScaffold` and related score analysis widgets to improve flexibility and robustness, especially around the display of PR cards and semester picker configuration. It also fixes some UI and data handling edge cases for better user experience.

**ScoreScaffold and Score Analysis UI improvements:**

* Added a new `showPRCard` property to `ScoreScaffold` and related widgets, allowing consumers to control the visibility of the PR card in the analysis tab. The default is now `true` for backward compatibility. [[1]](diffhunk://#diff-4c8d323557aee3444014ad4d94d0b22c7e1212d8ff6a4a7013d4ecac82d05322R28-R32) [[2]](diffhunk://#diff-4c8d323557aee3444014ad4d94d0b22c7e1212d8ff6a4a7013d4ecac82d05322R58-R61) [[3]](diffhunk://#diff-4c8d323557aee3444014ad4d94d0b22c7e1212d8ff6a4a7013d4ecac82d05322R94) [[4]](diffhunk://#diff-4c8d323557aee3444014ad4d94d0b22c7e1212d8ff6a4a7013d4ecac82d05322R340) [[5]](diffhunk://#diff-4c8d323557aee3444014ad4d94d0b22c7e1212d8ff6a4a7013d4ecac82d05322R444) [[6]](diffhunk://#diff-4c8d323557aee3444014ad4d94d0b22c7e1212d8ff6a4a7013d4ecac82d05322R456) [[7]](diffhunk://#diff-4c8d323557aee3444014ad4d94d0b22c7e1212d8ff6a4a7013d4ecac82d05322R472) [[8]](diffhunk://#diff-4c8d323557aee3444014ad4d94d0b22c7e1212d8ff6a4a7013d4ecac82d05322R759-R765) [[9]](diffhunk://#diff-4c8d323557aee3444014ad4d94d0b22c7e1212d8ff6a4a7013d4ecac82d05322R782-R785)
* Added `semesterPickerUiConfig` to `ScoreScaffold` for more customizable semester picker UI. [[1]](diffhunk://#diff-4c8d323557aee3444014ad4d94d0b22c7e1212d8ff6a4a7013d4ecac82d05322R28-R32) [[2]](diffhunk://#diff-4c8d323557aee3444014ad4d94d0b22c7e1212d8ff6a4a7013d4ecac82d05322R103-R105) [[3]](diffhunk://#diff-4c8d323557aee3444014ad4d94d0b22c7e1212d8ff6a4a7013d4ecac82d05322R172-L172)
* Refactored the `AppBar` in `ScoreScaffold` to always left-align the title, simplify the widget tree, and consistently space actions and pickers. [[1]](diffhunk://#diff-4c8d323557aee3444014ad4d94d0b22c7e1212d8ff6a4a7013d4ecac82d05322R150-L157) [[2]](diffhunk://#diff-4c8d323557aee3444014ad4d94d0b22c7e1212d8ff6a4a7013d4ecac82d05322R172-L172)

**Score Analysis and GPA Card robustness:**

* In `ScoreGPACard`, scores that cannot be parsed now display a placeholder entry with a dash and zero values, preventing missing or broken rows in the GPA table.
* The grade point column in the GPA card is widened and now shows a dash for invalid values instead of "0.0", improving readability and accuracy. [[1]](diffhunk://#diff-c9507c9d5946ca79bd0913668bb1deae2f1e094d18190b07e3e6cba351f76604L828-R841) [[2]](diffhunk://#diff-c9507c9d5946ca79bd0913668bb1deae2f1e094d18190b07e3e6cba351f76604L874-R889)

**Code quality and consistency:**

* Cleaned up code formatting by removing unnecessary line breaks and simplifying boolean expressions for better readability. [[1]](diffhunk://#diff-4c8d323557aee3444014ad4d94d0b22c7e1212d8ff6a4a7013d4ecac82d05322L649-R658) [[2]](diffhunk://#diff-4c8d323557aee3444014ad4d94d0b22c7e1212d8ff6a4a7013d4ecac82d05322L959-R976) [[3]](diffhunk://#diff-4c8d323557aee3444014ad4d94d0b22c7e1212d8ff6a4a7013d4ecac82d05322L1090-R1100) [[4]](diffhunk://#diff-4c8d323557aee3444014ad4d94d0b22c7e1212d8ff6a4a7013d4ecac82d05322L1104-R1115)

These changes collectively make the score analysis UI more flexible for consumers, more robust in handling edge cases, and more visually consistent.